### PR TITLE
Removed babel-polyfill from webpack entry point to fix the duplicate babel-polyfill in EPC.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2395,7 +2395,7 @@
     },
     "babel-helper-builder-binary-assignment-operator-visitor": {
       "version": "6.24.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
       "requires": {
         "babel-helper-explode-assignable-expression": "^6.24.1",
@@ -2405,7 +2405,7 @@
     },
     "babel-helper-call-delegate": {
       "version": "6.24.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
       "requires": {
         "babel-helper-hoist-variables": "^6.24.1",
@@ -2416,7 +2416,7 @@
     },
     "babel-helper-define-map": {
       "version": "6.26.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
       "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
       "requires": {
         "babel-helper-function-name": "^6.24.1",
@@ -2427,7 +2427,7 @@
     },
     "babel-helper-explode-assignable-expression": {
       "version": "6.24.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
       "requires": {
         "babel-runtime": "^6.22.0",
@@ -2437,7 +2437,7 @@
     },
     "babel-helper-function-name": {
       "version": "6.24.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
       "requires": {
         "babel-helper-get-function-arity": "^6.24.1",
@@ -2449,7 +2449,7 @@
     },
     "babel-helper-get-function-arity": {
       "version": "6.24.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
       "requires": {
         "babel-runtime": "^6.22.0",
@@ -2458,7 +2458,7 @@
     },
     "babel-helper-hoist-variables": {
       "version": "6.24.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
       "requires": {
         "babel-runtime": "^6.22.0",
@@ -2467,7 +2467,7 @@
     },
     "babel-helper-optimise-call-expression": {
       "version": "6.24.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
       "requires": {
         "babel-runtime": "^6.22.0",
@@ -2476,7 +2476,7 @@
     },
     "babel-helper-regex": {
       "version": "6.26.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
       "requires": {
         "babel-runtime": "^6.26.0",
@@ -2486,7 +2486,7 @@
     },
     "babel-helper-remap-async-to-generator": {
       "version": "6.24.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
       "requires": {
         "babel-helper-function-name": "^6.24.1",
@@ -2498,7 +2498,7 @@
     },
     "babel-helper-replace-supers": {
       "version": "6.24.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
       "requires": {
         "babel-helper-optimise-call-expression": "^6.24.1",
@@ -2523,7 +2523,7 @@
     },
     "babel-messages": {
       "version": "6.23.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/babel-messages/-/babel-messages-6.23.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "requires": {
         "babel-runtime": "^6.22.0"
@@ -2531,7 +2531,7 @@
     },
     "babel-plugin-check-es2015-constants": {
       "version": "6.22.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "requires": {
         "babel-runtime": "^6.22.0"
@@ -2612,22 +2612,22 @@
     },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
       "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
     },
     "babel-plugin-syntax-exponentiation-operator": {
       "version": "6.13.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
       "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
     },
     "babel-plugin-syntax-trailing-function-commas": {
       "version": "6.22.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
       "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
     },
     "babel-plugin-transform-async-to-generator": {
       "version": "6.24.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
       "requires": {
         "babel-helper-remap-async-to-generator": "^6.24.1",
@@ -2637,7 +2637,7 @@
     },
     "babel-plugin-transform-es2015-arrow-functions": {
       "version": "6.22.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
       "requires": {
         "babel-runtime": "^6.22.0"
@@ -2645,7 +2645,7 @@
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
       "version": "6.22.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
       "requires": {
         "babel-runtime": "^6.22.0"
@@ -2653,7 +2653,7 @@
     },
     "babel-plugin-transform-es2015-block-scoping": {
       "version": "6.26.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
       "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
       "requires": {
         "babel-runtime": "^6.26.0",
@@ -2665,7 +2665,7 @@
     },
     "babel-plugin-transform-es2015-classes": {
       "version": "6.24.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
       "requires": {
         "babel-helper-define-map": "^6.24.1",
@@ -2681,7 +2681,7 @@
     },
     "babel-plugin-transform-es2015-computed-properties": {
       "version": "6.24.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
       "requires": {
         "babel-runtime": "^6.22.0",
@@ -2690,7 +2690,7 @@
     },
     "babel-plugin-transform-es2015-destructuring": {
       "version": "6.23.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
       "requires": {
         "babel-runtime": "^6.22.0"
@@ -2698,7 +2698,7 @@
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
       "version": "6.24.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
       "requires": {
         "babel-runtime": "^6.22.0",
@@ -2707,7 +2707,7 @@
     },
     "babel-plugin-transform-es2015-for-of": {
       "version": "6.23.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
       "requires": {
         "babel-runtime": "^6.22.0"
@@ -2715,7 +2715,7 @@
     },
     "babel-plugin-transform-es2015-function-name": {
       "version": "6.24.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
       "requires": {
         "babel-helper-function-name": "^6.24.1",
@@ -2725,7 +2725,7 @@
     },
     "babel-plugin-transform-es2015-literals": {
       "version": "6.22.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
       "requires": {
         "babel-runtime": "^6.22.0"
@@ -2733,7 +2733,7 @@
     },
     "babel-plugin-transform-es2015-modules-amd": {
       "version": "6.24.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
       "requires": {
         "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
@@ -2754,7 +2754,7 @@
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
       "version": "6.24.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
       "requires": {
         "babel-helper-hoist-variables": "^6.24.1",
@@ -2764,7 +2764,7 @@
     },
     "babel-plugin-transform-es2015-modules-umd": {
       "version": "6.24.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
       "requires": {
         "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
@@ -2774,7 +2774,7 @@
     },
     "babel-plugin-transform-es2015-object-super": {
       "version": "6.24.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
       "requires": {
         "babel-helper-replace-supers": "^6.24.1",
@@ -2783,7 +2783,7 @@
     },
     "babel-plugin-transform-es2015-parameters": {
       "version": "6.24.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
       "requires": {
         "babel-helper-call-delegate": "^6.24.1",
@@ -2796,7 +2796,7 @@
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
       "version": "6.24.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
       "requires": {
         "babel-runtime": "^6.22.0",
@@ -2805,7 +2805,7 @@
     },
     "babel-plugin-transform-es2015-spread": {
       "version": "6.22.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
       "requires": {
         "babel-runtime": "^6.22.0"
@@ -2813,7 +2813,7 @@
     },
     "babel-plugin-transform-es2015-sticky-regex": {
       "version": "6.24.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
       "requires": {
         "babel-helper-regex": "^6.24.1",
@@ -2823,7 +2823,7 @@
     },
     "babel-plugin-transform-es2015-template-literals": {
       "version": "6.22.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
       "requires": {
         "babel-runtime": "^6.22.0"
@@ -2831,7 +2831,7 @@
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
       "version": "6.23.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
       "requires": {
         "babel-runtime": "^6.22.0"
@@ -2839,7 +2839,7 @@
     },
     "babel-plugin-transform-es2015-unicode-regex": {
       "version": "6.24.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
       "requires": {
         "babel-helper-regex": "^6.24.1",
@@ -2849,7 +2849,7 @@
     },
     "babel-plugin-transform-exponentiation-operator": {
       "version": "6.24.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
       "requires": {
         "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
@@ -2859,7 +2859,7 @@
     },
     "babel-plugin-transform-regenerator": {
       "version": "6.26.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
       "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
       "requires": {
         "regenerator-transform": "^0.10.0"
@@ -2867,7 +2867,7 @@
     },
     "babel-plugin-transform-strict-mode": {
       "version": "6.24.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
       "requires": {
         "babel-runtime": "^6.22.0",
@@ -2965,7 +2965,7 @@
     },
     "babel-template": {
       "version": "6.26.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/babel-template/-/babel-template-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "requires": {
         "babel-runtime": "^6.26.0",
@@ -2977,7 +2977,7 @@
     },
     "babel-traverse": {
       "version": "6.26.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "requires": {
         "babel-code-frame": "^6.26.0",
@@ -3001,14 +3001,14 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/ms/-/ms-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
     "babel-types": {
       "version": "6.26.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/babel-types/-/babel-types-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "requires": {
         "babel-runtime": "^6.26.0",
@@ -5454,7 +5454,7 @@
     },
     "extend-object": {
       "version": "1.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/extend-object/-/extend-object-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/extend-object/-/extend-object-1.0.0.tgz",
       "integrity": "sha1-QlFPhAFdE1bK9Rh5ad+yvBvaCCM="
     },
     "extend-shallow": {
@@ -5568,7 +5568,7 @@
     },
     "filetransfer": {
       "version": "2.0.5",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/filetransfer/-/filetransfer-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/filetransfer/-/filetransfer-2.0.5.tgz",
       "integrity": "sha1-iHyARv5UbsiugVwzAaXDE1+js10=",
       "requires": {
         "async": "^0.9.0",
@@ -5578,7 +5578,7 @@
       "dependencies": {
         "async": {
           "version": "0.9.2",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/async/-/async-0.9.2.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
           "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
         }
       }
@@ -6785,7 +6785,7 @@
     },
     "intersect": {
       "version": "0.1.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/intersect/-/intersect-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/intersect/-/intersect-0.1.0.tgz",
       "integrity": "sha1-AaZRNFvVWnvlCuLw9yV/i6EULMs="
     },
     "invariant": {
@@ -7299,7 +7299,7 @@
     },
     "jingle-filetransfer-session-purecloud": {
       "version": "3.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/jingle-filetransfer-session-purecloud/-/jingle-filetransfer-session-purecloud-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/jingle-filetransfer-session-purecloud/-/jingle-filetransfer-session-purecloud-3.0.0.tgz",
       "integrity": "sha1-ghOan/7GsnX1gOTPe7bVP9N9bLU=",
       "requires": {
         "extend-object": "^1.0.0",
@@ -7452,7 +7452,7 @@
     },
     "jxt-xmpp-types": {
       "version": "2.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/jxt-xmpp-types/-/jxt-xmpp-types-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/jxt-xmpp-types/-/jxt-xmpp-types-2.1.1.tgz",
       "integrity": "sha1-wmFjb9Vw9rqM5rb8yCL5i0VYhrY=",
       "requires": {
         "jxt": "^3.0.1",
@@ -7580,7 +7580,7 @@
     },
     "lodash._baseassign": {
       "version": "3.2.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
       "requires": {
         "lodash._basecopy": "^3.0.0",
@@ -7589,17 +7589,17 @@
     },
     "lodash._basecopy": {
       "version": "3.0.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
       "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
     },
     "lodash._bindcallback": {
       "version": "3.0.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
       "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
     },
     "lodash._createassigner": {
       "version": "3.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
       "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
       "requires": {
         "lodash._bindcallback": "^3.0.0",
@@ -7609,17 +7609,17 @@
     },
     "lodash._getnative": {
       "version": "3.9.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
       "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
     },
     "lodash._isiterateecall": {
       "version": "3.0.9",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
       "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
     },
     "lodash.assign": {
       "version": "3.2.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/lodash.assign/-/lodash.assign-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
       "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
       "requires": {
         "lodash._baseassign": "^3.0.0",
@@ -7640,12 +7640,12 @@
     },
     "lodash.isarguments": {
       "version": "3.1.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
     },
     "lodash.isarray": {
       "version": "3.0.4",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
     },
     "lodash.islength": {
@@ -7656,7 +7656,7 @@
     },
     "lodash.keys": {
       "version": "3.1.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "requires": {
         "lodash._getnative": "^3.0.0",
@@ -7672,7 +7672,7 @@
     },
     "lodash.restparam": {
       "version": "3.6.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
       "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
     },
     "log-symbols": {
@@ -9959,7 +9959,7 @@
     },
     "regexpu-core": {
       "version": "2.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/regexpu-core/-/regexpu-core-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "requires": {
         "regenerate": "^1.2.1",
@@ -9988,12 +9988,12 @@
     },
     "regjsgen": {
       "version": "0.2.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/regjsgen/-/regjsgen-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
       "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
     },
     "regjsparser": {
       "version": "0.1.5",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/regjsparser/-/regjsparser-0.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "requires": {
         "jsesc": "~0.5.0"
@@ -11543,7 +11543,7 @@
     },
     "to-fast-properties": {
       "version": "1.0.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
     },
     "to-object-path": {
@@ -12249,7 +12249,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -12270,12 +12271,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -12290,17 +12293,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -12417,7 +12423,8 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -12429,6 +12436,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -12443,6 +12451,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -12450,12 +12459,14 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -12474,6 +12485,7 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -12554,7 +12566,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -12566,6 +12579,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -12651,7 +12665,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -12687,6 +12702,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -12706,6 +12722,7 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -12749,12 +12766,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -13411,7 +13430,7 @@
     },
     "webrtcsupport": {
       "version": "1.3.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/webrtcsupport/-/webrtcsupport-1.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/webrtcsupport/-/webrtcsupport-1.3.2.tgz",
       "integrity": "sha1-Thd3RxqtpI9fSo6Jnpdde4HSjwA="
     },
     "well-known-symbols": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,7 @@ module.exports = (env) => {
   const filename = file + extension;
   return {
     target: node ? 'node' : 'web',
-    entry: ['babel-polyfill', './src/client.js'],
+    entry: './src/client.js',
     mode: minimize ? 'production' : 'development',
     optimization: {
       minimize


### PR DESCRIPTION
Removing `babel-polyfill` from the webpack entry point fixes the EPC duplicate polyfill issue. I think consuming clients should pull in any necessary polyfills they want/need. I may be wrong, but it doesn't look like streaming-client needs the polyfill. 