### PR TITLE
Updated webpack build to include babel's transform-runtime instead of the full babel-polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1268,6 +1268,18 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/plugin-transform-runtime": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.6.2.tgz",
+      "integrity": "sha512-cqULw/QB4yl73cS5Y0TZlQSjDvNkzDbu0FurTZyHlJpWE5T3PCMdnyV+xXoH1opr1ldyHODe3QAX3OMAii5NxA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "resolve": "^1.8.1",
+        "semver": "^5.5.1"
+      }
+    },
     "@babel/plugin-transform-shorthand-properties": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz",
@@ -1476,6 +1488,21 @@
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.4.tgz",
           "integrity": "sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ==",
           "dev": true
+        }
+      }
+    },
+    "@babel/runtime": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.3.tgz",
+      "integrity": "sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==",
+      "requires": {
+        "regenerator-runtime": "^0.13.2"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
         }
       }
     },
@@ -2961,6 +2988,13 @@
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.10",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
+          "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+        }
       }
     },
     "babel-template": {
@@ -4136,11 +4170,6 @@
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
-    },
-    "core-js": {
-      "version": "2.6.9",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/core-js/-/core-js-2.6.9.tgz",
-      "integrity": "sha1-a0shRiDINBUuF5Mjcn/Bl0GwhPI="
     },
     "core-js-compat": {
       "version": "3.1.4",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   },
   "author": "",
   "dependencies": {
+    "@babel/runtime": "^7.6.3",
     "backoff-web": "^1.0.1",
     "limiter": "^1.1.0",
     "purecloud-streaming-client-webrtc-sessions": "^7.2.10",
@@ -83,6 +84,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.5.4",
+    "@babel/plugin-transform-runtime": "^7.6.2",
     "@babel/preset-env": "^7.5.4",
     "@babel/register": "^7.4.4",
     "atob": "^2.1.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,10 +38,12 @@ module.exports = (env) => {
     module: {
       rules: [
         {
+          exclude: /(node_modules)/,
           test: /\.js$/,
           loader: 'babel-loader',
           query: {
-            presets: ['@babel/preset-env']
+            presets: ['@babel/preset-env'],
+            plugins: ['@babel/plugin-transform-runtime']
           }
         }
       ]


### PR DESCRIPTION
TLDR: use `'@babel/plugin-transform-runtime'` instead of `'babel-polyfill'`

Long story: `babel-polyfill` can only be loaded once per browser page. Ie, if two libs or apps try to load it in the same page, it will throw an error (I don't love that implementation). But, babel and their infinite config options has a `transform-runtime` plugin that will essentially bundle the needed parts of the polyfill into the lib/app. This way other applications can use streaming-client without the `babel-polyfill` collision. 