### PR TITLE
Correctly register handlers for individual topics when directly subsc…

### DIFF
--- a/src/notifications.js
+++ b/src/notifications.js
@@ -137,10 +137,28 @@ export default class Notification {
   }
 
   createSubscription (topic, handler) {
-    let handlers = this.topicHandlers(topic);
-    if (!handlers.includes(handler)) {
-      handlers.push(handler);
+    const topics = [];
+
+    // Register handlers for precombined topics
+    if (topic.includes('?')) {
+      const split = topic.split('?');
+      const prefix = split[0];
+      const postfixes = split[1] && split[1].split('&');
+      if (postfixes && postfixes.length) {
+        postfixes.forEach(postfix => {
+          topics.push(`${prefix}.${postfix}`);
+        });
+      }
+    } else {
+      topics.push(topic);
     }
+
+    topics.forEach(t => {
+      let handlers = this.topicHandlers(t);
+      if (!handlers.includes(handler)) {
+        handlers.push(handler);
+      }
+    });
   }
 
   removeSubscription (topic, handler) {

--- a/test/unit/notifications.test.js
+++ b/test/unit/notifications.test.js
@@ -393,3 +393,27 @@ test('notifications | mapCompineTopics should not combine already combined topic
   t.is(reducedTopics[1].id, 'v2.users.731c4a20-e6c2-443a-b361-39bcb9e087b7?geolocation&presence&routingStatus&conversationsummary&outofoffice');
   t.is(reducedTopics[2].id, 'v2.users.660b6ba5-5e69-4f55-a487-d44cee0f7ce7?geolocation&presence&conversations');
 });
+
+test('notifications | createSubscription should correctly register handlers for precombined topics', t => {
+  const client = new Client({
+    apiHost: 'inindca.com'
+  });
+  const notification = new Notifications(client);
+
+  const topic = 'v2.users.731c4a20-e6c2-443a-b361-39bcb9e087b7?geolocation&presence&routingStatus&conversationsummary';
+  const singleTopic = 'v2.users.660b6ba5-5e69-4f55-a487-d44cee0f7ce7.presence';
+  const noPosfixTopic = 'v2.users.8b67e4d1-9758-4285-8c45-b49fedff3f99?';
+  const handler = sinon.stub();
+
+  notification.createSubscription(topic, handler);
+  t.is(notification.subscriptions['v2.users.731c4a20-e6c2-443a-b361-39bcb9e087b7.geolocation'][0], handler);
+  t.is(notification.subscriptions['v2.users.731c4a20-e6c2-443a-b361-39bcb9e087b7.presence'][0], handler);
+  t.is(notification.subscriptions['v2.users.731c4a20-e6c2-443a-b361-39bcb9e087b7.routingStatus'][0], handler);
+  t.is(notification.subscriptions['v2.users.731c4a20-e6c2-443a-b361-39bcb9e087b7.conversationsummary'][0], handler);
+
+  notification.createSubscription(singleTopic, handler);
+  t.is(notification.subscriptions['v2.users.660b6ba5-5e69-4f55-a487-d44cee0f7ce7.presence'][0], handler);
+
+  notification.createSubscription(noPosfixTopic, handler);
+  t.is(notification.subscriptions['v2.users.8b67e4d1-9758-4285-8c45-b49fedff3f99'], undefined);
+});


### PR DESCRIPTION
Fixes an issue where handlers weren't correctly running if a consumer directly subscribed with a precombined topic: 
If a consumer used a precombined topic like `v2.users.731c4a20-e6c2-443a-b361-39bcb9e087b7?geolocation&presence&routingStatus&conversationsummary` with subscribe(), when an event for an individual topic like `v2.users.731c4a20-e6c2-443a-b361-39bcb9e087b7.geolocation` was received, the handler meant for it would not run (because the key for the handler would be `v2.users.731c4a20-e6c2-443a-b361-39bcb9e087b7?geolocation&presence&routingStatus&conversationsummary`).