### PR TITLE
[NO-JIRA] pass immediate true when not testing debounceResubscribe

### DIFF
--- a/test/unit/notifications.test.js
+++ b/test/unit/notifications.test.js
@@ -569,9 +569,9 @@ test('notifications | subscribe registers topic priorities if supplied', t => {
   const notification = new Notifications(client);
 
   const handler = sinon.stub();
-  notification.expose.subscribe('topic.test', handler, false, 1);
+  notification.expose.subscribe('topic.test', handler, true, 1);
   t.is(notification.topicPriorities.topic.test, 1);
-  notification.expose.subscribe('topic.test2', handler, false);
+  notification.expose.subscribe('topic.test2', handler, true);
   t.is(notification.topicPriorities.topic.test2, undefined);
 });
 


### PR DESCRIPTION
The immediate flag should be set to true on tests using the subscribe function to not interfere with other tests that are run simultaneously. With the exception of the test that is specifically testing the debouncedResubscribe functionality (subscribe and unsubscribe work when denounced). 