### PR TITLE
STREAM-892: add enablePartialBulkResubscribe option for notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # [Unreleased](https://github.com/purecloudlabs/genesys-cloud-streaming-client/compare/v19.3.1...HEAD)
 ### Added
 * [STREAM-865](https://inindca.atlassian.net/browse/STREAM-865) - Generate a test report in JUnit.xml format.
+* [STREAM-892](https://inindca.atlassian.net/browse/STREAM-892) - Add `enablePartialBulkResubscribe` client option to make notifications bulk subscription changes succeed or fail each topic independently rather than a single failed topic causing the whole bulk operation to fail.
 
 # [v19.3.1](https://github.com/purecloudlabs/genesys-cloud-streaming-client/compare/v19.3.0...v19.3.1)
 * [STREAM-801](https://inindca.atlassian.net/browse/STREAM-801) - Update genesys-cloud-client-logger and axios to address Snyk vulnerability.

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "@babel/runtime": "^7.12.0",
         "@rollup/plugin-commonjs": "^22.0.0-1",
         "@rollup/plugin-node-resolve": "^9.0.0",
+        "@types/debounce-promise": "^3.1.9",
         "@types/jest": "^26.0.3",
         "@types/lodash.throttle": "^4.1.6",
         "@types/nock": "^11.1.0",
@@ -2640,6 +2641,13 @@
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
+    },
+    "node_modules/@types/debounce-promise": {
+      "version": "3.1.9",
+      "resolved": "https://nexus.use1.infra-pure.cloud/repository/npm-cache/@types/debounce-promise/-/debounce-promise-3.1.9.tgz",
+      "integrity": "sha512-awNxydYSU+E2vL7EiOAMtiSOfL5gUM5X4YSE2A92qpxDJQ/rXz6oMPYBFDcDywlUmvIDI6zsqgq17cGm5CITQw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "0.0.39",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "@babel/runtime": "^7.12.0",
     "@rollup/plugin-commonjs": "^22.0.0-1",
     "@rollup/plugin-node-resolve": "^9.0.0",
+    "@types/debounce-promise": "^3.1.9",
     "@types/jest": "^26.0.3",
     "@types/lodash.throttle": "^4.1.6",
     "@types/nock": "^11.1.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,6 @@ export * from './types/media-session';
 export * from './types/interfaces';
 export * from './messenger';
 export { HttpClient } from './http-client';
-export { StreamingClientError, parseJwt } from './utils';
+export { StreamingClientError, StreamingSubscriptionError, parseJwt } from './utils';
 
 export default Client;

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -1,11 +1,13 @@
 import { Agent } from 'stanza';
 import { PubsubEvent, PubsubSubscription, PubsubSubscriptionWithOptions } from 'stanza/protocol';
-const debounce = require('debounce-promise');
+import debounce from 'debounce-promise';
 
 import { Client } from './client';
-import { RequestApiOptions, StreamingClientExtension } from './types/interfaces';
+import { IClientOptions, RequestApiOptions, StreamingClientExtension } from './types/interfaces';
 import { NamedAgent } from './types/named-agent';
 import { splitIntoIndividualTopics } from './utils';
+import { StreamingSubscriptionError } from './';
+import { AxiosResponse } from 'axios';
 
 const PUBSUB_HOST_DEFAULT = 'notifications.mypurecloud.com';
 const MAX_SUBSCRIBABLE_TOPICS = 1000;
@@ -22,14 +24,18 @@ export class Notifications implements StreamingClientExtension {
   subscriptions: any;
   bulkSubscriptions: any;
   topicPriorities: any;
-  debouncedResubscribe: any;
+  debouncedResubscribe: () => Promise<BulkSubscribeResult>;
 
-  constructor (client) {
+  enablePartialBulkResubscribe: boolean;
+
+  constructor (client, options?: IClientOptions) {
     this.subscriptions = {};
     this.bulkSubscriptions = {};
     this.topicPriorities = {};
 
     this.client = client;
+
+    this.enablePartialBulkResubscribe = options?.enablePartialBulkResubscribe ?? false;
 
     client.on('pubsub:event', this.pubsubEvent.bind(this));
     client.on('connected', this.subscriptionsKeepAlive.bind(this));
@@ -54,7 +60,7 @@ export class Notifications implements StreamingClientExtension {
 
     if (needsToResub) {
       this.client.logger.info('resubscribing due to hard reconnect');
-      this.debouncedResubscribe();
+      void this.debouncedResubscribe();
     }
   }
 
@@ -196,7 +202,7 @@ export class Notifications implements StreamingClientExtension {
     return keptTopics;
   }
 
-  makeBulkSubscribeRequest (topics: string[], options): Promise<any> {
+  makeBulkSubscribeRequest (topics: string[], options): Promise<AxiosResponse<ChannelTopicsEntityListing>> {
     const requestOptions: RequestApiOptions = {
       method: options.replace ? 'put' : 'post',
       host: this.client.config.apiHost,
@@ -205,7 +211,13 @@ export class Notifications implements StreamingClientExtension {
       logger: this.client.logger
     };
     const channelId = this.stanzaInstance!.channelId;
-    return this.client.http.requestApi(`notifications/channels/${channelId}/subscriptions`, requestOptions);
+    let path = `notifications/channels/${channelId}/subscriptions`;
+
+    if (this.enablePartialBulkResubscribe) {
+      path += '?ignoreErrors=true';
+    }
+
+    return this.client.http.requestApi(path, requestOptions);
   }
 
   createSubscription (topic: string, handler: (obj?: any) => void): void {
@@ -264,13 +276,13 @@ export class Notifications implements StreamingClientExtension {
     return activeTopics;
   }
 
-  resubscribe (): Promise<any> {
+  resubscribe (): Promise<BulkSubscribeResult> {
     const bulkSubs = Object.keys(this.bulkSubscriptions);
 
     /* if we don't have bulk or individual subs, we don't need to resubscribe */
     const noTopics = bulkSubs.length + this.getActiveIndividualTopics().length === 0;
     if (noTopics) {
-      return Promise.resolve();
+      return Promise.resolve({});
     }
 
     /* only pass in bulk subs with the replace flag – bulkSubscribe() will handle merging our individual topics (see PCM-1846) */
@@ -328,12 +340,12 @@ export class Notifications implements StreamingClientExtension {
     });
   }
 
-  subscribe (topic: string, handler?: (..._: any[]) => void, immediate?: boolean, priority?: number): Promise<any> {
+  async subscribe (topic: string, handler?: (..._: any[]) => void, immediate?: boolean, priority?: number): Promise<TopicSubscribeResult> {
     if (priority) {
       this.setTopicPriorities({ [topic]: priority });
     }
 
-    let promise;
+    let promise: Promise<unknown>;
     if (!immediate) {
       // let this and any other subscribe/unsubscribe calls roll in, then trigger a whole resubscribe
       promise = this.debouncedResubscribe();
@@ -345,7 +357,19 @@ export class Notifications implements StreamingClientExtension {
     } else {
       this.bulkSubscriptions[topic] = true;
     }
-    return promise;
+    const result = await promise;
+    // Assume topic subscription succeeded if promise is resolved...
+    let topicResult: TopicSubscribeResult = { topic, state: 'Permitted' };
+    // ... but if partial bulk resubscribe is enabled, use topic's individual result from the API response.
+    if (this.enablePartialBulkResubscribe && result && typeof result === 'object' && isTopicSubscribeResult(result[topic])) {
+      topicResult = result[topic];
+    }
+    // Topic result other than state=Permitted becomes a StreamingSubscriptionError promise rejection.
+    if (topicResult.state !== 'Permitted') {
+      const message = topicResult.rejectionReason || `Failed to subscribe topic ${topic}`;
+      throw new StreamingSubscriptionError(message, topic, 'subscribe');
+    }
+    return topicResult;
   }
 
   unsubscribe (topic: string, handler?: (..._: any[]) => void, immediate?: boolean): Promise<any> {
@@ -369,7 +393,7 @@ export class Notifications implements StreamingClientExtension {
     topics: string[],
     options: BulkSubscribeOpts = { replace: false, force: false },
     priorities: { [topicName: string]: number } = {}
-  ): Promise<any> {
+  ): Promise<BulkSubscribeResult> {
     this.setTopicPriorities(priorities);
 
     let toSubscribe = mergeAndDedup(topics, []);
@@ -382,7 +406,16 @@ export class Notifications implements StreamingClientExtension {
       this.subscriptions = {};
     }
 
-    await this.makeBulkSubscribeRequest(toSubscribe, options);
+    const response = await this.makeBulkSubscribeRequest(toSubscribe, options);
+    let topicResponseEntities: ChannelTopicResponseEntity[] = [];
+    if (response && response.data && 'entities' in response.data && Array.isArray(response.data.entities)) {
+      topicResponseEntities = response.data.entities;
+    }
+    const topicResponsesById: { [topic: string]: ChannelTopicResponseEntity } = {};
+    for (const topicEntity of topicResponseEntities) {
+      topicResponsesById[topicEntity.id] = topicEntity;
+    }
+    const result: BulkSubscribeResult = {};
 
     if (options.replace) {
       this.bulkSubscriptions = {};
@@ -390,7 +423,20 @@ export class Notifications implements StreamingClientExtension {
 
     topics.forEach(topic => {
       this.bulkSubscriptions[topic] = true;
+
+      if (this.enablePartialBulkResubscribe) {
+        if (topic in topicResponsesById) {
+          const { state, rejectionReason } = topicResponsesById[topic];
+          result[topic] = { topic, state, rejectionReason };
+        } else {
+          result[topic] = { topic, state: 'Unknown' };
+        }
+      } else {
+        result[topic] = { topic, state: 'Permitted' };
+      }
     });
+
+    return result;
   }
 
   get expose (): NotificationsAPI {
@@ -415,4 +461,35 @@ export interface NotificationsAPI {
 export interface BulkSubscribeOpts {
   replace?: boolean;
   force?: boolean;
+}
+
+export interface BulkSubscribeResult {
+  [topic: string]: TopicSubscribeResult;
+}
+
+export interface TopicSubscribeResult {
+  topic: string;
+  state: 'Permitted' | 'Rejected' | 'Unknown';
+  rejectionReason?: string;
+}
+
+function isTopicSubscribeResult (value: unknown): value is TopicSubscribeResult {
+  let hasTopic = false;
+  let hasValidState = false;
+  if (value && typeof value === 'object') {
+    hasTopic = 'topic' in value && typeof (value as { topic: unknown }).topic === 'string';
+    hasValidState = 'state' in value && ['Permitted', 'Rejected', 'Unknown'].includes((value as { state: string }).state);
+  }
+  return hasTopic && hasValidState;
+}
+
+export interface ChannelTopicResponseEntity {
+  id: string;
+  state: 'Permitted' | 'Rejected';
+  rejectionReason?: string;
+  selfUri?: string;
+}
+
+export interface ChannelTopicsEntityListing {
+  entities: ChannelTopicResponseEntity[];
 }

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -24,6 +24,8 @@ export interface IClientOptions {
   appVersion?: string;
   appId?: string;
   customHeaders?: ICustomHeader; // Genesys internal use only - non-Genesys apps that pass in custom headers will be ignored.
+  /** Allow bulk topic resubscribe to succeed or fail per-topic rather than all or nothing */
+  enablePartialBulkResubscribe?: boolean;
 }
 
 export interface ICustomHeader {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,6 +25,14 @@ export class StreamingClientError extends Error {
   }
 }
 
+export class StreamingSubscriptionError extends Error {
+  name = 'StreamingSubscriptionError';
+
+  constructor (message: string, public readonly topic?: string, public readonly operation?: 'subscribe' | 'unsubscribe') {
+    super(message);
+  }
+}
+
 /* istanbul ignore next */
 export function timeoutPromise (fn: Function, timeoutMs: number, msg: string, details?: any) {
   return new Promise<any>(function (resolve, reject) {

--- a/test/unit/notifications.test.ts
+++ b/test/unit/notifications.test.ts
@@ -123,22 +123,35 @@ describe('Notifications', () => {
       bulkSubscribeUrl = `https://api.example.com/api/v2/notifications/channels/${channelId}/subscriptions`;
       axiosMock.onPut(bulkSubscribeUrl).reply((config) => {
         const topics = JSON.parse(config.data).map((topic) => topic.id);
-        if (topics.includes('b.topic')) {
-          return [403, {
-            message: 'The user does not have permission "b.topic:view" required for topic "b.topic"',
-            code: 'notification.unauthorized.topic',
-            status: 403,
-          }];
+        const response: ChannelTopicsEntityListing = { entities: [] };
+        for (const topic of topics) {
+          if (topic.includes('bad')) {
+            // In the non-ignoreErrors case a bad topic bails early with 403 response for the bad topic
+            return [403, {
+              message: `The user does not have permission "${topic}:view" required for topic "${topic}"`,
+              code: 'notification.unauthorized.topic',
+              status: 403,
+            }];
+          } else if (!topic.includes('unknown')) {
+            // Everything defaults to success except topics containing "unknown" which we purposely
+            // omit the response for in order to test the fallback behavior of no API result for topic.
+            response.entities.push({ id: topic, state: 'Permitted' });
+          }
         }
-        return [200, { entities: [{ id: 'a.topic', state: 'Permitted' }] }];
+        return [200, response];
       });
       axiosMock.onPut(`${bulkSubscribeUrl}?ignoreErrors=true`).reply((config) => {
         const topics = JSON.parse(config.data).map((topic) => topic.id);
-        const response: ChannelTopicsEntityListing = {
-          entities: [{ id: 'a.topic', state: 'Permitted' }]
-        };
-        if (topics.includes('b.topic')) {
-          response.entities.push({ id: 'b.topic', state: 'Rejected', rejectionReason: 'The user does not have permissions required for topic b.topic' });
+        const response: ChannelTopicsEntityListing = { entities: [] };
+        for (const topic of topics) {
+          if (topic.includes('bad')) {
+            // In the ignoreErrors case a bad topic just adds a Rejected topic result to the overall success response payload
+            response.entities.push({ id: topic, state: 'Rejected', rejectionReason: `The user does not have permissions required for topic ${topic}` });
+          } else if (!topic.includes('unknown')) {
+            // Everything defaults to success except topics containing "unknown" which we purposely
+            // omit the response for in order to test the fallback behavior of no API result for topic.
+            response.entities.push({ id: topic, state: 'Permitted' });
+          }
         }
         return [200, response];
       });
@@ -158,7 +171,7 @@ describe('Notifications', () => {
         notification.stanzaInstance = getFakeStanzaClient();
       });
       it('should not add ignoreErrors param to bulk resubscribe', async () => {
-        await notification.subscribe('a.topic', () => {});
+        await notification.subscribe('a.ok.topic', () => {});
         expect(axiosMock.history.put.length).toEqual(1);
         expect(axiosMock.history.put[0].url).not.toContain('?ignoreErrors');
       });
@@ -167,18 +180,18 @@ describe('Notifications', () => {
         let bResult: undefined | 'fulfilled' | 'rejected';
         let cResult: undefined | 'fulfilled' | 'rejected';
         await Promise.all([
-          notification.subscribe('a.topic').then(() => { aResult = 'fulfilled'; }, () => { aResult = 'rejected'; }),
-          notification.subscribe('b.topic').then(() => { bResult = 'fulfilled'; }, () => { bResult = 'rejected'; }),
-          notification.subscribe('c.topic').then(() => { cResult = 'fulfilled'; }, () => { cResult = 'rejected'; }),
+          notification.subscribe('a.ok.topic').then(() => { aResult = 'fulfilled'; }, () => { aResult = 'rejected'; }),
+          notification.subscribe('b.bad.topic').then(() => { bResult = 'fulfilled'; }, () => { bResult = 'rejected'; }),
+          notification.subscribe('c.unknown.topic').then(() => { cResult = 'fulfilled'; }, () => { cResult = 'rejected'; }),
         ]);
-        // All subscribe() calls reject because the bulk subscribe response is 403 due to b.topic
+        // All subscribe() calls reject because the bulk subscribe response is 403 due to b.bad.topic
         expect(aResult).toEqual('rejected');
         expect(bResult).toEqual('rejected');
         expect(cResult).toEqual('rejected');
         // But all 3 topics should remain in bulkSubscriptions
-        expect(Object.keys(notification.bulkSubscriptions)).toContain('a.topic');
-        expect(Object.keys(notification.bulkSubscriptions)).toContain('b.topic');
-        expect(Object.keys(notification.bulkSubscriptions)).toContain('c.topic');
+        expect(Object.keys(notification.bulkSubscriptions)).toContain('a.ok.topic');
+        expect(Object.keys(notification.bulkSubscriptions)).toContain('b.bad.topic');
+        expect(Object.keys(notification.bulkSubscriptions)).toContain('c.unknown.topic');
       });
     });
 
@@ -188,7 +201,7 @@ describe('Notifications', () => {
         notification.stanzaInstance = getFakeStanzaClient();
       });
       it('should add ?ignoreErrors=true to bulk resubscribe', async () => {
-        await notification.subscribe('a.topic', () => {});
+        await notification.subscribe('a.ok.topic', () => {});
         expect(axiosMock.history.put.length).toEqual(1);
         expect(axiosMock.history.put[0].url).toContain('?ignoreErrors');
       });
@@ -197,19 +210,21 @@ describe('Notifications', () => {
         let bResult: undefined | 'fulfilled' | 'rejected';
         let cResult: undefined | 'fulfilled' | 'rejected';
         await Promise.all([
-          notification.subscribe('a.topic').then(() => { aResult = 'fulfilled'; }, () => { aResult = 'rejected'; }),
-          notification.subscribe('b.topic').then(() => { bResult = 'fulfilled'; }, () => { bResult = 'rejected'; }),
-          notification.subscribe('c.topic').then(() => { cResult = 'fulfilled'; }, () => { cResult = 'rejected'; }),
+          notification.subscribe('a.ok.topic').then(() => { aResult = 'fulfilled'; }, () => { aResult = 'rejected'; }),
+          notification.subscribe('b.bad.topic').then(() => { bResult = 'fulfilled'; }, () => { bResult = 'rejected'; }),
+          // API response will not include info for c.unknown.topic... this tests edge case when topic's API response is missing
+          notification.subscribe('c.unknown.topic').then(() => { cResult = 'fulfilled'; }, () => { cResult = 'rejected'; }),
         ]);
         expect(aResult).toEqual('fulfilled');
-        // b.topic subscribe() call is rejected because bulk subscribe result is "Rejected" for that topic
+        // b.bad.topic subscribe() call is rejected because bulk subscribe result is "Rejected" for that topic
         expect(bResult).toEqual('rejected');
-        // c.topic subscribe() call is rejected because bulk subscribe result is "Unknown" for that topic (not in the API response)
+        // c.unknown.topic result will not be in the API response (intentionally, see mock above).
+        // We default to rejected in this case since we don't know if the server has the sub or not.
         expect(cResult).toEqual('rejected');
         // all 3 topics get added to bulkSubscriptions
-        expect(Object.keys(notification.bulkSubscriptions)).toContain('a.topic');
-        expect(Object.keys(notification.bulkSubscriptions)).toContain('b.topic');
-        expect(Object.keys(notification.bulkSubscriptions)).toContain('c.topic');
+        expect(Object.keys(notification.bulkSubscriptions)).toContain('a.ok.topic');
+        expect(Object.keys(notification.bulkSubscriptions)).toContain('b.bad.topic');
+        expect(Object.keys(notification.bulkSubscriptions)).toContain('c.unknown.topic');
       });
     });
   });

--- a/test/unit/notifications.test.ts
+++ b/test/unit/notifications.test.ts
@@ -3,13 +3,13 @@
 import WildEmitter from 'wildemitter';
 import nock from 'nock';
 
-import { Notifications } from '../../src/notifications';
+import { ChannelTopicsEntityListing, Notifications } from '../../src/notifications';
 import { Agent } from 'stanza';
 import { HttpClient } from '../../src/http-client';
 import { EventEmitter } from 'stream';
 import { NamedAgent } from '../../src/types/named-agent';
 import { v4 } from 'uuid';
-import axios from 'axios';
+import axios, { Axios, AxiosResponse } from 'axios';
 import AxiosMockAdapter from 'axios-mock-adapter';
 
 const exampleTopics = require('../helpers/example-topics.json');
@@ -106,6 +106,111 @@ describe('Notifications', () => {
       notification.stanzaInstance = undefined;
       notification.handleStanzaInstanceChange(newInstance);
       expect(resubSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('enablePartialBulkResubscribe', () => {
+    let client: Client;
+    let notification: Notifications;
+    let axiosMock = new AxiosMockAdapter(axios);
+    let bulkSubscribeUrl: string;
+
+    beforeEach(() => {
+      client = new Client({
+        channelId,
+        apiHost: 'example.com',
+      });
+      bulkSubscribeUrl = `https://api.example.com/api/v2/notifications/channels/${channelId}/subscriptions`;
+      axiosMock.onPut(bulkSubscribeUrl).reply((config) => {
+        const topics = JSON.parse(config.data).map((topic) => topic.id);
+        if (topics.includes('b.topic')) {
+          return [403, {
+            message: 'The user does not have permission "b.topic:view" required for topic "b.topic"',
+            code: 'notification.unauthorized.topic',
+            status: 403,
+          }];
+        }
+        return [200, { entities: [{ id: 'a.topic', state: 'Permitted' }] }];
+      });
+      axiosMock.onPut(`${bulkSubscribeUrl}?ignoreErrors=true`).reply((config) => {
+        const topics = JSON.parse(config.data).map((topic) => topic.id);
+        const response: ChannelTopicsEntityListing = {
+          entities: [{ id: 'a.topic', state: 'Permitted' }]
+        };
+        if (topics.includes('b.topic')) {
+          response.entities.push({ id: 'b.topic', state: 'Rejected', rejectionReason: 'The user does not have permissions required for topic b.topic' });
+        }
+        return [200, response];
+      });
+    });
+    afterEach(() => {
+      axiosMock.reset();
+    });
+
+    it('should not be enabled by default', () => {
+      notification = new Notifications(client);
+      expect(notification.enablePartialBulkResubscribe).toBe(false);
+    });
+
+    describe('when not enabled', () => {
+      beforeEach(() => {
+        notification = new Notifications(client, { host: 'localhost', enablePartialBulkResubscribe: false });
+        notification.stanzaInstance = getFakeStanzaClient();
+      });
+      it('should not add ignoreErrors param to bulk resubscribe', async () => {
+        await notification.subscribe('a.topic', () => {});
+        expect(axiosMock.history.put.length).toEqual(1);
+        expect(axiosMock.history.put[0].url).not.toContain('?ignoreErrors');
+      });
+      it('should fail all subscribe() calls from the same debounce interval with the same 403 error if one fails', async () => {
+        let aResult: undefined | 'fulfilled' | 'rejected';
+        let bResult: undefined | 'fulfilled' | 'rejected';
+        let cResult: undefined | 'fulfilled' | 'rejected';
+        await Promise.all([
+          notification.subscribe('a.topic').then(() => { aResult = 'fulfilled'; }, () => { aResult = 'rejected'; }),
+          notification.subscribe('b.topic').then(() => { bResult = 'fulfilled'; }, () => { bResult = 'rejected'; }),
+          notification.subscribe('c.topic').then(() => { cResult = 'fulfilled'; }, () => { cResult = 'rejected'; }),
+        ]);
+        // All subscribe() calls reject because the bulk subscribe response is 403 due to b.topic
+        expect(aResult).toEqual('rejected');
+        expect(bResult).toEqual('rejected');
+        expect(cResult).toEqual('rejected');
+        // But all 3 topics should remain in bulkSubscriptions
+        expect(Object.keys(notification.bulkSubscriptions)).toContain('a.topic');
+        expect(Object.keys(notification.bulkSubscriptions)).toContain('b.topic');
+        expect(Object.keys(notification.bulkSubscriptions)).toContain('c.topic');
+      });
+    });
+
+    describe('when enabled', () => {
+      beforeEach(() => {
+        notification = new Notifications(client, { host: 'localhost', enablePartialBulkResubscribe: true });
+        notification.stanzaInstance = getFakeStanzaClient();
+      });
+      it('should add ?ignoreErrors=true to bulk resubscribe', async () => {
+        await notification.subscribe('a.topic', () => {});
+        expect(axiosMock.history.put.length).toEqual(1);
+        expect(axiosMock.history.put[0].url).toContain('?ignoreErrors');
+      });
+      it('should individually succeed or fail subscribe() calls from the same debounce interval based on API response', async () => {
+        let aResult: undefined | 'fulfilled' | 'rejected';
+        let bResult: undefined | 'fulfilled' | 'rejected';
+        let cResult: undefined | 'fulfilled' | 'rejected';
+        await Promise.all([
+          notification.subscribe('a.topic').then(() => { aResult = 'fulfilled'; }, () => { aResult = 'rejected'; }),
+          notification.subscribe('b.topic').then(() => { bResult = 'fulfilled'; }, () => { bResult = 'rejected'; }),
+          notification.subscribe('c.topic').then(() => { cResult = 'fulfilled'; }, () => { cResult = 'rejected'; }),
+        ]);
+        expect(aResult).toEqual('fulfilled');
+        // b.topic subscribe() call is rejected because bulk subscribe result is "Rejected" for that topic
+        expect(bResult).toEqual('rejected');
+        // c.topic subscribe() call is rejected because bulk subscribe result is "Unknown" for that topic (not in the API response)
+        expect(cResult).toEqual('rejected');
+        // all 3 topics get added to bulkSubscriptions
+        expect(Object.keys(notification.bulkSubscriptions)).toContain('a.topic');
+        expect(Object.keys(notification.bulkSubscriptions)).toContain('b.topic');
+        expect(Object.keys(notification.bulkSubscriptions)).toContain('c.topic');
+      });
     });
   });
 
@@ -251,7 +356,7 @@ describe('Notifications', () => {
 
     // subscribing
     (notification.stanzaInstance as jest.Mocked<NamedAgent>).subscribeToNode.mockResolvedValue({});
-    jest.spyOn(notification, 'bulkSubscribe').mockResolvedValue(undefined);
+    jest.spyOn(notification, 'bulkSubscribe').mockResolvedValue({});
     const handler = jest.fn();
     const firstSubscription = notification.expose.subscribe('topic.test', handler);
 
@@ -285,11 +390,10 @@ describe('Notifications', () => {
     const notification = new Notifications(client);
     notification.stanzaInstance = getFakeStanzaClient();
 
-
     (notification.stanzaInstance as jest.Mocked<NamedAgent>).subscribeToNode.mockResolvedValue({});
-    jest.spyOn(notification, 'makeBulkSubscribeRequest').mockResolvedValue(undefined);
+    jest.spyOn(notification, 'makeBulkSubscribeRequest').mockResolvedValue({} as AxiosResponse);
 
-    const topic1 = 'v2.users.731c4a20-e6c2-443a-b361-39bcb9e087b7.geolocation'
+    const topic1 = 'v2.users.731c4a20-e6c2-443a-b361-39bcb9e087b7.geolocation';
     const topic2 = 'v2.users.731c4a20-e6c2-443a-b361-39bcb9e087b7.presence';
     const handler = () => { };
 
@@ -326,10 +430,9 @@ describe('Notifications', () => {
     const notification = new Notifications(client);
     notification.stanzaInstance = getFakeStanzaClient();
 
-
     // subscribing
     (notification.stanzaInstance as jest.Mocked<NamedAgent>).subscribeToNode.mockResolvedValue({});
-    jest.spyOn(notification, 'bulkSubscribe').mockResolvedValue(undefined);
+    jest.spyOn(notification, 'bulkSubscribe').mockResolvedValue({});
     await Promise.all([
       notification.expose.subscribe('topic.test', jest.fn()),
       notification.expose.subscribe('topic.test', jest.fn()),
@@ -358,7 +461,6 @@ describe('Notifications', () => {
     const notification = new Notifications(client);
     notification.stanzaInstance = getFakeStanzaClient();
 
-
     client.connected = true;
     (notification.stanzaInstance as jest.Mocked<NamedAgent>).subscribeToNode.mockRejectedValue(new Error('test'));
     (notification.stanzaInstance as jest.Mocked<NamedAgent>).unsubscribeFromNode.mockRejectedValue(new Error('test'));
@@ -382,7 +484,7 @@ describe('Notifications', () => {
     (notification.stanzaInstance as jest.Mocked<NamedAgent>).unsubscribeFromNode.mockResolvedValue({});
     client.emit('connected');
     client.connected = true;
-    jest.spyOn(notification, 'bulkSubscribe').mockResolvedValue(undefined);
+    jest.spyOn(notification, 'bulkSubscribe').mockResolvedValue({});
     client.emit('pubsub:event', SUBSCRIPTIONS_EXPIRING);
     expect(notification.bulkSubscribe).not.toHaveBeenCalled();
     expect(notification.stanzaInstance!.subscribeToNode).not.toHaveBeenCalled();
@@ -456,7 +558,7 @@ describe('Notifications', () => {
     (notification.stanzaInstance as jest.Mocked<NamedAgent>).unsubscribeFromNode.mockResolvedValue({});
     client.emit('connected');
     client.connected = true;
-    jest.spyOn(notification, 'makeBulkSubscribeRequest').mockResolvedValue(undefined);
+    jest.spyOn(notification, 'makeBulkSubscribeRequest').mockResolvedValue({} as AxiosResponse);
 
     const handler = jest.fn();
     const handler2 = jest.fn();
@@ -476,12 +578,11 @@ describe('Notifications', () => {
     const notification = new Notifications(client);
     notification.stanzaInstance = getFakeStanzaClient();
 
-
     (notification.stanzaInstance as jest.Mocked<NamedAgent>).subscribeToNode.mockResolvedValue({});
     (notification.stanzaInstance as jest.Mocked<NamedAgent>).unsubscribeFromNode.mockResolvedValue({});
     client.emit('connected');
     client.connected = true;
-    jest.spyOn(notification, 'makeBulkSubscribeRequest').mockResolvedValue(undefined);
+    jest.spyOn(notification, 'makeBulkSubscribeRequest').mockResolvedValue({} as AxiosResponse);
 
     const handler = jest.fn();
     const handler2 = jest.fn();
@@ -499,7 +600,6 @@ describe('Notifications', () => {
     const notification = new Notifications(client);
     notification.stanzaInstance = getFakeStanzaClient();
 
-
     const reducedTopics = notification.mapCombineTopics(exampleTopics);
     expect(reducedTopics.length).toBe(exampleTopics.length / 5);
   });
@@ -510,7 +610,6 @@ describe('Notifications', () => {
     });
     const notification = new Notifications(client);
     notification.stanzaInstance = getFakeStanzaClient();
-
 
     const topics = [
       'v2.users.8b67e4d1-9758-4285-8c45-b49fedff3f99.geolocation',
@@ -538,7 +637,6 @@ describe('Notifications', () => {
     const notification = new Notifications(client);
     notification.stanzaInstance = getFakeStanzaClient();
 
-
     const topics = [
       'v2.users.8b67e4d1-9758-4285-8c45-b49fedff3f99.geolocation',
       'v2.users.8b67e4d1-9758-4285-8c45-b49fedff3f99.routingStatus',
@@ -562,7 +660,6 @@ describe('Notifications', () => {
     });
     const notification = new Notifications(client);
     notification.stanzaInstance = getFakeStanzaClient();
-
 
     const topic = 'v2.users.731c4a20-e6c2-443a-b361-39bcb9e087b7?geolocation&presence&routingStatus&conversationsummary';
     const singleTopic = 'v2.users.660b6ba5-5e69-4f55-a487-d44cee0f7ce7.presence';
@@ -588,7 +685,6 @@ describe('Notifications', () => {
     });
     const notification = new Notifications(client);
     notification.stanzaInstance = getFakeStanzaClient();
-
 
     const topic = 'v2.users.731c4a20-e6c2-443a-b361-39bcb9e087b7?geolocation&presence&routingStatus&conversationsummary';
     const handler = jest.fn();
@@ -623,7 +719,6 @@ describe('Notifications', () => {
     const notification = new Notifications(client);
     notification.stanzaInstance = getFakeStanzaClient();
 
-
     const topicList: string[] = [];
     for (let i = 0; i < 1030; i++) {
       topicList.push(`v2.users.${i}.presence`);
@@ -648,7 +743,6 @@ describe('Notifications', () => {
     const notification = new Notifications(client);
     notification.stanzaInstance = getFakeStanzaClient();
 
-
     const topicList: string[] = [];
     for (let i = 0; i < 1030; i++) {
       topicList.push(`v2.users.${i}.presence`, `v2.users.${i}.geolocation`);
@@ -668,7 +762,6 @@ describe('Notifications', () => {
     });
     const notification = new Notifications(client);
     notification.stanzaInstance = getFakeStanzaClient();
-
 
     const topics = [
       'v2.users.8b67e4d1-9758-4285-8c45-b49fedff3f99.geolocation',
@@ -717,7 +810,6 @@ describe('Notifications', () => {
     const notification = new Notifications(client);
     notification.stanzaInstance = getFakeStanzaClient();
 
-
     notification.setTopicPriorities({ 'test.topic': 2, 'test.topic2': 1, 'test.topic3': 5, 'test.topic4': -1 });
     expect(notification.getTopicPriority('test.topic')).toBe(2);
     expect(notification.getTopicPriority('test.defaulttopicpriority')).toBe(0);
@@ -735,7 +827,6 @@ describe('Notifications', () => {
     });
     const notification = new Notifications(client);
     notification.stanzaInstance = getFakeStanzaClient();
-
 
     notification.setTopicPriorities({ 'test.topic': 2 });
     expect(notification.topicPriorities.test.topic).toBe(2);
@@ -761,7 +852,6 @@ describe('Notifications', () => {
     });
     const notification = new Notifications(client);
     notification.stanzaInstance = getFakeStanzaClient();
-
 
     notification.setTopicPriorities();
     notification.setTopicPriorities({ 'test.topic': 2, 'test.topic2': 5 });
@@ -795,7 +885,7 @@ describe('Notifications', () => {
     const notification = new Notifications(client);
     notification.stanzaInstance = getFakeStanzaClient();
 
-    jest.spyOn(notification, 'makeBulkSubscribeRequest').mockResolvedValue(undefined);
+    jest.spyOn(notification, 'makeBulkSubscribeRequest').mockResolvedValue({} as AxiosResponse);
 
     const priorities = {
       'topic.test.one': 1,
@@ -830,7 +920,6 @@ describe('Notifications', () => {
     const notification = new Notifications(client);
     notification.stanzaInstance = getFakeStanzaClient();
 
-
     const spy = jest.spyOn(client, 'emit');
     (client as any).emit('pubsub:event', noLongerSubscribed);
 
@@ -859,7 +948,6 @@ describe('Notifications', () => {
     });
     const notification = new Notifications(client);
     notification.stanzaInstance = getFakeStanzaClient();
-
 
     const spy = jest.spyOn(client, 'emit');
     (client as any).emit('pubsub:event', duplicateId);


### PR DESCRIPTION
Adds a new optional config property `enablePartialBulkResubscribe` that modifies the behavior of the Notifications module bulk subscribe to include `?ignoreErrors=true` on the PUT request to update the subscription. The bulk subscribe method is updated to always return a Promise for a BulkSubscribeResult that contains the status of each topic. This behavior is opt-in, so the default behavior stays the same as before.

The `?ignoreErrors=true` param on the public API endpoint corresponds to the `nofail` mode in hawk-consumer which makes bulk requests succeed with individual failure results instead of failing the entire bulk operation due to one of the topics failing (e.g. due to lack of permissions).