### PR TITLE
[STREAM-941] fix notifications.subscribe() result for internally combined topics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 # [Unreleased](https://github.com/purecloudlabs/genesys-cloud-streaming-client/compare/v19.4.0...HEAD)
+### Changed
+* [STREAM-941](https://inindca.atlassian.net/browse/STREAM-941) - Fix an issue where notifications.subscribe() with `enablePartialBulkResubscribe` would not resolve/reject based on API result when the requested topic was internally combined with others, e.g. "topic.a" and "topic.b" individually subscribed and bulk resubscribe combines them as "topic?a&b"
 
 # [v19.4.0](https://github.com/purecloudlabs/genesys-cloud-streaming-client/compare/v19.3.1...v19.4.0)
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,9 +42,9 @@
         "@babel/runtime": "^7.12.0",
         "@rollup/plugin-commonjs": "^22.0.0-1",
         "@rollup/plugin-node-resolve": "^13.0.6",
+        "@types/debounce-promise": "^3.1.9",
         "@types/eslint": "^8.56.12",
         "@types/estree": "^1.0.8",
-        "@types/debounce-promise": "^3.1.9",
         "@types/jest": "^26.0.3",
         "@types/lodash.throttle": "^4.1.6",
         "@types/nock": "^11.1.0",
@@ -3330,6 +3330,12 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@types/debounce-promise": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@types/debounce-promise/-/debounce-promise-3.1.9.tgz",
+      "integrity": "sha512-awNxydYSU+E2vL7EiOAMtiSOfL5gUM5X4YSE2A92qpxDJQ/rXz6oMPYBFDcDywlUmvIDI6zsqgq17cGm5CITQw==",
+      "dev": true
+    },
     "node_modules/@types/eslint": {
       "version": "8.56.12",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.12.tgz",
@@ -3350,12 +3356,6 @@
         "@types/eslint": "*",
         "@types/estree": "*"
       }
-    },
-    "node_modules/@types/debounce-promise": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/@types/debounce-promise/-/debounce-promise-3.1.9.tgz",
-      "integrity": "sha512-awNxydYSU+E2vL7EiOAMtiSOfL5gUM5X4YSE2A92qpxDJQ/rXz6oMPYBFDcDywlUmvIDI6zsqgq17cGm5CITQw==",
-      "dev": true
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -411,11 +411,26 @@ export class Notifications implements StreamingClientExtension {
     if (response && response.data && 'entities' in response.data && Array.isArray(response.data.entities)) {
       topicResponseEntities = response.data.entities;
     }
-    const topicResponsesById: { [topic: string]: ChannelTopicResponseEntity } = {};
-    for (const topicEntity of topicResponseEntities) {
-      topicResponsesById[topicEntity.id] = topicEntity;
-    }
     const result: BulkSubscribeResult = {};
+    for (const topicEntity of topicResponseEntities) {
+      const { id, state, rejectionReason } = topicEntity;
+      const topicResult = result[id] = { topic: id, state, rejectionReason };
+      // If response entity is a combined topic ID like "a.b?c&d" include individualized topic IDs
+      // as keys in the map. This could either point to the same result as the combined topic ID
+      // or to a specific result for that individual topic if backend provides a specific result.
+      // Example: caller asked to subscribe "a.b?c&d" but user lacks permission for topic "a.b.d"
+      // In this case, API response will include "a.b?c&d" as success along with "a.b.d" as failure.
+      if (id.includes('?')) {
+        for (const individualTopic of splitIntoIndividualTopics(id)) {
+          const hasIndividualTopicResult = (individualTopic in result);
+          // Only use the combined topic result for this individual topic ID if there isn't already
+          // a result for the individual topic itself. Exact topic result takes precedence.
+          if (!hasIndividualTopicResult) {
+            result[individualTopic] = topicResult;
+          }
+        }
+      }
+    }
 
     if (options.replace) {
       this.bulkSubscriptions = {};
@@ -423,18 +438,14 @@ export class Notifications implements StreamingClientExtension {
 
     topics.forEach(topic => {
       this.bulkSubscriptions[topic] = true;
-
-      if (this.enablePartialBulkResubscribe) {
-        if (topic in topicResponsesById) {
-          const { state, rejectionReason } = topicResponsesById[topic];
-          result[topic] = { topic, state, rejectionReason };
-        } else {
-          result[topic] = { topic, state: 'Unknown' };
-        }
-      } else {
-        result[topic] = { topic, state: 'Permitted' };
-      }
     });
+
+    // Add a fallback result for any topic in the toSubscribe list that isn't already in result.
+    // With partial bulk resubscribe enabled missing result means "Unknown" state but when not
+    // enabled the fallback is "Permitted" for backward compatibility (success response means OK).
+    for (const topic of toSubscribe) {
+      result[topic] ??= { topic, state: this.enablePartialBulkResubscribe ? 'Unknown' : 'Permitted' };
+    }
 
     return result;
   }

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -414,7 +414,7 @@ export class Notifications implements StreamingClientExtension {
     const result: BulkSubscribeResult = {};
     for (const topicEntity of topicResponseEntities) {
       const { id, state, rejectionReason } = topicEntity;
-      const topicResult = result[id] = { topic: id, state, rejectionReason };
+      result[id] = { topic: id, state, rejectionReason };
       // If response entity is a combined topic ID like "a.b?c&d" include individualized topic IDs
       // as keys in the map. This could either point to the same result as the combined topic ID
       // or to a specific result for that individual topic if backend provides a specific result.
@@ -422,11 +422,11 @@ export class Notifications implements StreamingClientExtension {
       // In this case, API response will include "a.b?c&d" as success along with "a.b.d" as failure.
       if (id.includes('?')) {
         for (const individualTopic of splitIntoIndividualTopics(id)) {
-          const hasIndividualTopicResult = (individualTopic in result);
+          const hasIndividualTopicResult = result.hasOwnProperty(individualTopic);
           // Only use the combined topic result for this individual topic ID if there isn't already
           // a result for the individual topic itself. Exact topic result takes precedence.
           if (!hasIndividualTopicResult) {
-            result[individualTopic] = topicResult;
+            result[individualTopic] = result[id];
           }
         }
       }

--- a/test/unit/notifications.test.ts
+++ b/test/unit/notifications.test.ts
@@ -11,6 +11,7 @@ import { NamedAgent } from '../../src/types/named-agent';
 import { v4 } from 'uuid';
 import axios, { Axios, AxiosResponse } from 'axios';
 import AxiosMockAdapter from 'axios-mock-adapter';
+import { splitIntoIndividualTopics } from '../../src/utils';
 
 const exampleTopics = require('../helpers/example-topics.json');
 
@@ -125,14 +126,14 @@ describe('Notifications', () => {
         const topics = JSON.parse(config.data).map((topic) => topic.id);
         const response: ChannelTopicsEntityListing = { entities: [] };
         for (const topic of topics) {
-          if (topic.includes('bad')) {
+          if (topic.includes('.bad')) {
             // In the non-ignoreErrors case a bad topic bails early with 403 response for the bad topic
             return [403, {
               message: `The user does not have permission "${topic}:view" required for topic "${topic}"`,
               code: 'notification.unauthorized.topic',
               status: 403,
             }];
-          } else if (!topic.includes('unknown')) {
+          } else if (!topic.includes('.unknown')) {
             // Everything defaults to success except topics containing "unknown" which we purposely
             // omit the response for in order to test the fallback behavior of no API result for topic.
             response.entities.push({ id: topic, state: 'Permitted' });
@@ -144,13 +145,22 @@ describe('Notifications', () => {
         const topics = JSON.parse(config.data).map((topic) => topic.id);
         const response: ChannelTopicsEntityListing = { entities: [] };
         for (const topic of topics) {
-          if (topic.includes('bad')) {
+          if (topic.includes('.bad')) {
             // In the ignoreErrors case a bad topic just adds a Rejected topic result to the overall success response payload
             response.entities.push({ id: topic, state: 'Rejected', rejectionReason: `The user does not have permissions required for topic ${topic}` });
-          } else if (!topic.includes('unknown')) {
+          } else if (!topic.includes('.unknown')) {
             // Everything defaults to success except topics containing "unknown" which we purposely
             // omit the response for in order to test the fallback behavior of no API result for topic.
             response.entities.push({ id: topic, state: 'Permitted' });
+          }
+          // For combined topics, the API response will include a Permitted result for the combined topic
+          // and a Rejected result for any constituent individual topic ID that failed within the combo.
+          if (topic.includes('?')) {
+            for (const individualTopic of splitIntoIndividualTopics(topic)) {
+              if (individualTopic.includes('.bad')) {
+                response.entities.push({ id: individualTopic, state: 'Rejected', rejectionReason: 'Individual topic rejection' });
+              }
+            }
           }
         }
         return [200, response];
@@ -225,6 +235,30 @@ describe('Notifications', () => {
         expect(Object.keys(notification.bulkSubscriptions)).toContain('a.ok.topic');
         expect(Object.keys(notification.bulkSubscriptions)).toContain('b.bad.topic');
         expect(Object.keys(notification.bulkSubscriptions)).toContain('c.unknown.topic');
+      });
+      it('should individually succeed or fail subscribe() calls that combine to a single topic', async () => {
+        let aResult: undefined | 'fulfilled' | 'rejected';
+        let bResult: undefined | 'fulfilled' | 'rejected';
+        await Promise.all([
+          notification.subscribe('topic.ok').then(() => { aResult = 'fulfilled'; }, () => { aResult = 'rejected'; }),
+          notification.subscribe('topic.bad').then(() => { bResult = 'fulfilled'; }, () => { bResult = 'rejected'; }),
+        ]);
+        expect(aResult).toEqual('fulfilled');
+        // topic.bad subscribe() call is rejected because bulk subscribe result is "Rejected" for that topic
+        // even though the API response will have a "Permitted" result for "topic?ok&bad&unknown"
+        expect(bResult).toEqual('rejected');
+        expect(Object.keys(notification.bulkSubscriptions)).toContain('topic.ok');
+        expect(Object.keys(notification.bulkSubscriptions)).toContain('topic.bad');
+      });
+      // Not sure this is desired behavior, but it's the actual behavior so this test documents that... :)
+      it('should succeed subscribe() call for combined topic even if individual topic fails', async () => {
+        let aResult: undefined | 'fulfilled' | 'rejected';
+        // In this case the API response is expected to have a "Permitted" result for "topic?ok&bad"
+        // But will also have a "Rejected" result for individual "topic.bad" (which we would only
+        // know if we had explicitly subscribed that topic).
+        await notification.subscribe('topic?ok&bad').then(() => { aResult = 'fulfilled'; }, () => { aResult = 'rejected'; });
+        expect(aResult).toEqual('fulfilled');
+        expect(Object.keys(notification.bulkSubscriptions)).toContain('topic?ok&bad');
       });
     });
   });


### PR DESCRIPTION
Fixes a couple issues related to the internal topic combining that caused incorrect or unexpected results for individual topic subscribes.

Example:
```ts
subscribe("topic.ok"); // expected to resolve
subscribe("topic.bad"); // expected to reject
```
Internally, this becomes a single entry in the bulk resubscribe: `topic?ok&bad`
Before this change, the code that looked for a result only knew to look for for `topic.ok` and `topic.bad` individually. It did not normalize the actual response entity `topic?ok&bad` to produce the individual results. Similarly, the bulk subscribe result generation was only using topics from the requested list to generate the result rather than starting from everything in the API response and only supplementing as needed.