### PR TITLE
[Stream-995] - Add 'missingPermissions' property to StreamingSubscriptionError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 # [Unreleased](https://github.com/purecloudlabs/genesys-cloud-streaming-client/compare/v19.4.1...HEAD)
+### Added
+* [STREAM-995](https://inindca.atlassian.net/browse/STREAM-995) - Include `missingPermissions` on topic subscribe Error
 ### Changed
 * [STREAM-997](https://inindca.atlassian.net/browse/STREAM-997) - Updated requestWithApiRetry to retry on network error codes. Added maxAttempts option to requestApiWithRetry.
 * [STREAM-1006](https://inindca.atlassian.net/browse/STREAM-1006) - Added ECONNRESET to the list of network error codes to retry on.

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -413,8 +413,8 @@ export class Notifications implements StreamingClientExtension {
     }
     const result: BulkSubscribeResult = {};
     for (const topicEntity of topicResponseEntities) {
-      const { id, state, rejectionReason } = topicEntity;
-      result[id] = { topic: id, state, rejectionReason };
+      const { id, state, rejectionReason, missingPermissions } = topicEntity;
+      result[id] = { topic: id, state, rejectionReason, missingPermissions };
       // If response entity is a combined topic ID like "a.b?c&d" include individualized topic IDs
       // as keys in the map. This could either point to the same result as the combined topic ID
       // or to a specific result for that individual topic if backend provides a specific result.
@@ -499,6 +499,7 @@ export interface ChannelTopicResponseEntity {
   id: string;
   state: 'Permitted' | 'Rejected';
   rejectionReason?: string;
+  missingPermissions?: string[];
   selfUri?: string;
 }
 

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -367,7 +367,7 @@ export class Notifications implements StreamingClientExtension {
     // Topic result other than state=Permitted becomes a StreamingSubscriptionError promise rejection.
     if (topicResult.state !== 'Permitted') {
       const message = topicResult.rejectionReason || `Failed to subscribe topic ${topic}`;
-      throw new StreamingSubscriptionError(message, topic, 'subscribe');
+      throw new StreamingSubscriptionError(message, topic, 'subscribe', topicResult.missingPermissions);
     }
     return topicResult;
   }
@@ -482,6 +482,7 @@ export interface TopicSubscribeResult {
   topic: string;
   state: 'Permitted' | 'Rejected' | 'Unknown';
   rejectionReason?: string;
+  missingPermissions?: string[];
 }
 
 function isTopicSubscribeResult (value: unknown): value is TopicSubscribeResult {

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -367,7 +367,8 @@ export class Notifications implements StreamingClientExtension {
     // Topic result other than state=Permitted becomes a StreamingSubscriptionError promise rejection.
     if (topicResult.state !== 'Permitted') {
       const message = topicResult.rejectionReason || `Failed to subscribe topic ${topic}`;
-      throw new StreamingSubscriptionError(message, topic, 'subscribe', topicResult.missingPermissions);
+      const missingPermissions = topicResult.missingPermissions;
+      throw new StreamingSubscriptionError(message, topic, 'subscribe', { missingPermissions });
     }
     return topicResult;
   }

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -174,6 +174,10 @@ export interface StreamingClientConnectOptions {
   maxDelayBetweenConnectionAttempts?: number;
 }
 
+export interface StreamingSubscriptionErrorDetails {
+  missingPermissions?: string[];
+}
+
 export type GenesysWebrtcBaseParams = { sessionId: string };
 export type GenesysWebrtcSdpParams = GenesysWebrtcBaseParams & { sdp: string; };
 export type GenesysWebrtcOfferParams = GenesysWebrtcSdpParams & {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,9 +27,11 @@ export class StreamingClientError extends Error {
 
 export class StreamingSubscriptionError extends Error {
   name = 'StreamingSubscriptionError';
+  missingPermissions?: string[];
 
-  constructor (message: string, public readonly topic?: string, public readonly operation?: 'subscribe' | 'unsubscribe') {
+  constructor (message: string, public readonly topic?: string, public readonly operation?: 'subscribe' | 'unsubscribe', missingPermissions?: string[]) {
     super(message);
+    this.missingPermissions = missingPermissions;
   }
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 import { v4 } from 'uuid';
 import { TimeoutError } from './types/timeout-error';
-import { StreamingClientErrorTypes } from './types/interfaces';
+import { StreamingClientErrorTypes, StreamingSubscriptionErrorDetails } from './types/interfaces';
 
 export class StreamingClientError extends Error {
   type: StreamingClientErrorTypes;
@@ -29,9 +29,9 @@ export class StreamingSubscriptionError extends Error {
   name = 'StreamingSubscriptionError';
   missingPermissions?: string[];
 
-  constructor (message: string, public readonly topic?: string, public readonly operation?: 'subscribe' | 'unsubscribe', missingPermissions?: string[]) {
+  constructor (message: string, public readonly topic?: string, public readonly operation?: 'subscribe' | 'unsubscribe', details?: StreamingSubscriptionErrorDetails) {
     super(message);
-    this.missingPermissions = missingPermissions;
+    this.missingPermissions = details?.missingPermissions;
   }
 }
 

--- a/test/unit/notifications.test.ts
+++ b/test/unit/notifications.test.ts
@@ -1,7 +1,6 @@
 'use strict';
 
 import WildEmitter from 'wildemitter';
-import nock from 'nock';
 
 import { ChannelTopicsEntityListing, Notifications } from '../../src/notifications';
 import { Agent } from 'stanza';
@@ -9,9 +8,10 @@ import { HttpClient } from '../../src/http-client';
 import { EventEmitter } from 'stream';
 import { NamedAgent } from '../../src/types/named-agent';
 import { v4 } from 'uuid';
-import axios, { Axios, AxiosResponse } from 'axios';
+import axios, { AxiosResponse } from 'axios';
 import AxiosMockAdapter from 'axios-mock-adapter';
 import { splitIntoIndividualTopics } from '../../src/utils';
+import { IClientOptions } from '../../src';
 
 const exampleTopics = require('../helpers/example-topics.json');
 
@@ -260,6 +260,39 @@ describe('Notifications', () => {
         expect(aResult).toEqual('fulfilled');
         expect(Object.keys(notification.bulkSubscriptions)).toContain('topic?ok&bad');
       });
+    });
+
+    it('StreamingSubscriptionError should include missingPermissions property', async () => {
+      const client = new Client({
+        apiHost: 'example.com',
+        channelId: 'notification-test-channel'
+      });
+
+      const notification = new Notifications(client, { enablePartialBulkResubscribe: true } as IClientOptions);
+      notification.stanzaInstance = getFakeStanzaClient();
+
+      (notification.stanzaInstance as jest.Mocked<NamedAgent>).subscribeToNode.mockResolvedValue({
+        'test.topic': {
+          topic: 'test.topic',
+          state: 'Rejected',
+          rejectionReason: 'we dont know sorry',
+          missingPermissions: ['who', 'do', 'you', 'think', 'you', 'are']
+        }
+      } as any);
+
+      try {
+        const handler = jest.fn();
+        const firstSubs = notification.expose.subscribe('test.topic', handler, true);
+        client.emit('connected');
+        client.connected = true;
+        await firstSubs;
+      } catch (e: any) {
+        expect(e.name).toBe('StreamingSubscriptionError');
+        expect(e.topic).toBe('test.topic');
+        expect(e.message).toBe('we dont know sorry');
+        expect(e.operation).toBe('subscribe');
+        expect(e.missingPermissions).toEqual(['who', 'do', 'you', 'think', 'you', 'are']);
+      }
     });
   });
 

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -58,6 +58,19 @@ describe('Utils', () => {
       expect(error.operation).toBe('subscribe');
       expect(error.missingPermissions).toEqual(missingPermissions);
     });
+
+    it('should create without details argument', () => {
+      const error = new utils.StreamingSubscriptionError(
+        'Subscription failed',
+        'test.topic',
+        'subscribe'
+      );
+
+      expect(error.name).toBe('StreamingSubscriptionError');
+      expect(error.message).toBe('Subscription failed');
+      expect(error.topic).toBe('test.topic');
+      expect(error.operation).toBe('subscribe');
+    });
   });
 
   describe('jid utils', () => {
@@ -83,6 +96,7 @@ describe('Utils', () => {
       expect(utils.isSoftphoneJid('sdkfjk@gjoll.test.com')).toBeTruthy();
       expect(utils.isSoftphoneJid('sdkfjk@test.com')).toBeFalsy();
       expect(utils.isSoftphoneJid('')).toBeFalsy();
+      expect(utils.isSoftphoneJid(null as any)).toBeFalsy();
     });
 
     it('isVideoJid', () => {

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -58,6 +58,19 @@ describe('Utils', () => {
       expect(error.operation).toBe('subscribe');
       expect(error.missingPermissions).toEqual(missingPermissions);
     });
+
+    it('should create without details argument', () => {
+      const error = new utils.StreamingSubscriptionError(
+        'Subscription failed',
+        'test.topic',
+        'subscribe'
+      );
+
+      expect(error.name).toBe('StreamingSubscriptionError');
+      expect(error.message).toBe('Subscription failed');
+      expect(error.topic).toBe('test.topic');
+      expect(error.operation).toBe('subscribe');
+    });
   });
 
   describe('jid utils', () => {

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -42,6 +42,24 @@ describe('Utils', () => {
     });
   });
 
+  describe('StreamingSubscriptionError', () => {
+    it('should create with missingPermissions property', () => {
+      const missingPermissions = ['abc.def', 'abc.def.ghi'];
+      const error = new utils.StreamingSubscriptionError(
+        'Subscription failed',
+        'test.topic',
+        'subscribe',
+        missingPermissions
+      );
+
+      expect(error.name).toBe('StreamingSubscriptionError');
+      expect(error.message).toBe('Subscription failed');
+      expect(error.topic).toBe('test.topic');
+      expect(error.operation).toBe('subscribe');
+      expect(error.missingPermissions).toEqual(missingPermissions);
+    });
+  });
+
   describe('jid utils', () => {
     it('isAcdJid', () => {
       expect(utils.isAcdJid('acd-sdkfjk@test.com')).toBeTruthy();

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -49,7 +49,7 @@ describe('Utils', () => {
         'Subscription failed',
         'test.topic',
         'subscribe',
-        missingPermissions
+        { missingPermissions }
       );
 
       expect(error.name).toBe('StreamingSubscriptionError');

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -58,19 +58,6 @@ describe('Utils', () => {
       expect(error.operation).toBe('subscribe');
       expect(error.missingPermissions).toEqual(missingPermissions);
     });
-
-    it('should create without details argument', () => {
-      const error = new utils.StreamingSubscriptionError(
-        'Subscription failed',
-        'test.topic',
-        'subscribe'
-      );
-
-      expect(error.name).toBe('StreamingSubscriptionError');
-      expect(error.message).toBe('Subscription failed');
-      expect(error.topic).toBe('test.topic');
-      expect(error.operation).toBe('subscribe');
-    });
   });
 
   describe('jid utils', () => {
@@ -96,7 +83,6 @@ describe('Utils', () => {
       expect(utils.isSoftphoneJid('sdkfjk@gjoll.test.com')).toBeTruthy();
       expect(utils.isSoftphoneJid('sdkfjk@test.com')).toBeFalsy();
       expect(utils.isSoftphoneJid('')).toBeFalsy();
-      expect(utils.isSoftphoneJid(null as any)).toBeFalsy();
     });
 
     it('isVideoJid', () => {


### PR DESCRIPTION
https://inindca.atlassian.net/browse/STREAM-995

Hawk Consumer now includes a new property which shows which permissions a user is missing when trying to subscribe to a topic.

This is from trying to subscribe to something we are not allowed to in WebDir ran locally. The error now contains the `missingPermissions` property.
<img width="1186" height="153" alt="image" src="https://github.com/user-attachments/assets/1aaf3de3-da13-4def-acdf-c8dfb9f740b5" />
