### PR TITLE
[STREAM-1271] - catch debouncedResubscribe error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 * [STREAM-1208](https://inindca.atlassian.net/browse/STREAM-1208) - Update axios to 1.13.5 to address vulnerability.
 
+### Fixed
+* [STREAM-1271](https://inindca.atlassian.net/browse/STREAM-1271) - Fix unhandled errors during hard reconnect resubscribe in `handleStanzaInstanceChange`
+
 # [v19.5.0](https://github.com/purecloudlabs/genesys-cloud-streaming-client/compare/v19.4.1...v19.5.0)
 ### Added
 * [STREAM-995](https://inindca.atlassian.net/browse/STREAM-995) - Include `missingPermissions` on topic subscribe Error.

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -63,7 +63,11 @@ export class Notifications implements StreamingClientExtension {
 
     if (needsToResub) {
       this.client.logger.info('resubscribing due to hard reconnect');
-      void this.debouncedResubscribe();
+      this.debouncedResubscribe().catch((err) => {
+        const msg = 'Error resubscribing to topics';
+        this.client.logger.error(msg, err);
+        this.client.emit('pubsub:error' as any, { msg, err });
+      });
     }
   }
 
@@ -486,7 +490,9 @@ export class Notifications implements StreamingClientExtension {
 
 export interface NotificationsAPI {
   subscribe (topic: string, handler?: (..._: any[]) => void, immediate?: boolean, priority?: number): Promise<any>;
+
   unsubscribe (topic: string, handler?: (..._: any[]) => void, immediate?: boolean): Promise<any>;
+
   bulkSubscribe (
     topics: string[],
     options?: BulkSubscribeOpts,
@@ -515,7 +521,9 @@ function isTopicSubscribeResult (value: unknown): value is TopicSubscribeResult 
   let hasValidState = false;
   if (value && typeof value === 'object') {
     hasTopic = 'topic' in value && typeof (value as { topic: unknown }).topic === 'string';
-    hasValidState = 'state' in value && ['Permitted', 'Rejected', 'Unknown'].includes((value as { state: string }).state);
+    hasValidState = 'state' in value && ['Permitted', 'Rejected', 'Unknown'].includes((value as {
+      state: string
+    }).state);
   }
   return hasTopic && hasValidState;
 }

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -490,9 +490,7 @@ export class Notifications implements StreamingClientExtension {
 
 export interface NotificationsAPI {
   subscribe (topic: string, handler?: (..._: any[]) => void, immediate?: boolean, priority?: number): Promise<any>;
-
   unsubscribe (topic: string, handler?: (..._: any[]) => void, immediate?: boolean): Promise<any>;
-
   bulkSubscribe (
     topics: string[],
     options?: BulkSubscribeOpts,
@@ -521,9 +519,7 @@ function isTopicSubscribeResult (value: unknown): value is TopicSubscribeResult 
   let hasValidState = false;
   if (value && typeof value === 'object') {
     hasTopic = 'topic' in value && typeof (value as { topic: unknown }).topic === 'string';
-    hasValidState = 'state' in value && ['Permitted', 'Rejected', 'Unknown'].includes((value as {
-      state: string
-    }).state);
+    hasValidState = 'state' in value && ['Permitted', 'Rejected', 'Unknown'].includes((value as { state: string }).state);
   }
   return hasTopic && hasValidState;
 }

--- a/test/unit/notifications.test.ts
+++ b/test/unit/notifications.test.ts
@@ -84,7 +84,7 @@ describe('Notifications', () => {
       });
       notification = new Notifications(client);
       stanzaInstance = notification.stanzaInstance = getFakeStanzaClient();
-      resubSpy = notification.debouncedResubscribe = jest.fn();
+      resubSpy = notification.debouncedResubscribe = jest.fn().mockResolvedValue({});
     });
 
     it('should not resub if same channelId', () => {
@@ -107,6 +107,25 @@ describe('Notifications', () => {
       notification.stanzaInstance = undefined;
       notification.handleStanzaInstanceChange(newInstance);
       expect(resubSpy).not.toHaveBeenCalled();
+    });
+
+    it('should emit pubsub:error if hard reconnect resubscribe fails', async () => {
+      const newInstance = getFakeStanzaClient();
+      newInstance.channelId = 'newChannel';
+      const error = new Error('intentional test error');
+      resubSpy.mockRejectedValue(error);
+
+      const errorEvent = new Promise<void>((resolve) => {
+        (client as unknown as EventEmitter).on('pubsub:error', (err) => {
+          expect(err.msg).toBe('Error resubscribing to topics');
+          expect(err.err).toBe(error);
+          resolve();
+        });
+      });
+
+      notification.handleStanzaInstanceChange(newInstance);
+      await errorEvent;
+      expect(resubSpy).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
Somebody from the JM team was asking if we could catch this.
`handleStanzaInstanceChange` calls `debouncedResubscribe` and does not wait for it or attaches any handlers. So if `debouncedResubscribe` fails, nothing catches it, and it bubbles up to the GlobalHandler.