### PR TITLE
STREAM-1362: Retry notification subscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 * [STREAM-1488](https://inindca.atlassian.net/browse/STREAM-1488) - Update `axios` to v1.15.2
+* [STREAM-1362](https://inindca.atlassian.net/browse/STREAM-1362) - Retry notification subscription
 
 # [v19.6.0](https://github.com/purecloudlabs/genesys-cloud-streaming-client/compare/v19.6.0...HEAD)
 ### Added

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -215,7 +215,8 @@ export class Notifications implements StreamingClientExtension {
       host: this.client.config.apiHost,
       authToken: this.client.config.authToken,
       data: JSON.stringify(this.mapCombineTopics(topics)),
-      logger: this.client.logger
+      logger: this.client.logger,
+      maxAttempts: 3
     };
     const channelId = this.stanzaInstance!.channelId;
     let path = `notifications/channels/${channelId}/subscriptions`;
@@ -224,7 +225,7 @@ export class Notifications implements StreamingClientExtension {
       path += '?ignoreErrors=true';
     }
 
-    return this.client.http.requestApi(path, requestOptions);
+    return this.client.http.requestApiWithRetry(path, requestOptions, 2000).promise;
   }
 
   createSubscription (topic: string, handler: (obj?: any) => void): void {

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -5,10 +5,9 @@ import debounce from 'debounce-promise';
 import { Client } from './client';
 import { IClientOptions, RequestApiOptions, StreamingClientExtension } from './types/interfaces';
 import { NamedAgent } from './types/named-agent';
-import { splitIntoIndividualTopics } from './utils';
+import { splitIntoIndividualTopics, RetryPromise } from './utils';
 import { StreamingSubscriptionError } from './';
 import { AxiosResponse } from 'axios';
-import { RetryPromise } from './utils';
 
 const PUBSUB_HOST_DEFAULT = 'notifications.mypurecloud.com';
 const MAX_SUBSCRIBABLE_TOPICS = 1000;

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -30,6 +30,7 @@ export class Notifications implements StreamingClientExtension {
 
   private internalSubscriptions: string[];
   private pendingBulkSubscribeRetry?: RetryPromise<any>;
+  private pendingConnectedWait?: { cancel: (reason?: any) => void };
 
   constructor (client, options?: IClientOptions) {
     this.subscriptions = {};
@@ -210,14 +211,41 @@ export class Notifications implements StreamingClientExtension {
     return keptTopics;
   }
 
-  makeBulkSubscribeRequest (topics: string[], options): Promise<AxiosResponse<ChannelTopicsEntityListing>> {
-    // Cancel any in-flight retry from a previous bulk subscribe. If the topic list has changed
-    // (subscribe/unsubscribe called between retries), the stale request would send an outdated
-    // topic list. Since bulk subscribes with replace=true use PUT (full replacement), only the
-    // most recent request matters.
+  async makeBulkSubscribeRequest (topics: string[], options): Promise<AxiosResponse<ChannelTopicsEntityListing>> {
+    // Cancel any in-flight retry or connected-wait from a previous bulk subscribe.
+    // If the topic list has changed (subscribe/unsubscribe called between retries),
+    // the stale request would send an outdated topic list. Since bulk subscribes with
+    // replace=true use PUT (full replacement), only the most recent request matters.
+    if (this.pendingConnectedWait) {
+      this.pendingConnectedWait.cancel(new Error('Superseded by newer bulk subscribe request'));
+      this.pendingConnectedWait = undefined;
+    }
     if (this.pendingBulkSubscribeRetry && !this.pendingBulkSubscribeRetry.hasCompleted()) {
       this.client.logger.info('Cancelling previous bulk subscribe retry — new request supersedes it');
       this.pendingBulkSubscribeRetry.cancel(new Error('Superseded by newer bulk subscribe request'));
+    }
+
+    // If the client is not connected, wait for reconnection before attempting the request.
+    // This prevents firing requests against a dead/stale channel ID which would result in
+    // 400 errors (notification.unable.to.get.channel.id). After reconnection, the stanza
+    // instance will have the fresh channel ID from the new connection.
+    if (!this.client.connected) {
+      this.client.logger.info('Client not connected, waiting for reconnection before bulk subscribe', {
+        topicCount: topics.length
+      });
+      await new Promise<void>((resolve, reject) => {
+        const onConnected = () => {
+          this.pendingConnectedWait = undefined;
+          resolve();
+        };
+        this.client.once('connected', onConnected);
+        this.pendingConnectedWait = {
+          cancel: (reason?: any) => {
+            this.client.off('connected', onConnected);
+            reject(reason);
+          }
+        };
+      });
     }
 
     const requestOptions: RequestApiOptions = {

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -8,6 +8,7 @@ import { NamedAgent } from './types/named-agent';
 import { splitIntoIndividualTopics } from './utils';
 import { StreamingSubscriptionError } from './';
 import { AxiosResponse } from 'axios';
+import { RetryPromise } from './utils';
 
 const PUBSUB_HOST_DEFAULT = 'notifications.mypurecloud.com';
 const MAX_SUBSCRIBABLE_TOPICS = 1000;
@@ -29,6 +30,7 @@ export class Notifications implements StreamingClientExtension {
   enablePartialBulkResubscribe: boolean;
 
   private internalSubscriptions: string[];
+  private pendingBulkSubscribeRetry?: RetryPromise<any>;
 
   constructor (client, options?: IClientOptions) {
     this.subscriptions = {};
@@ -210,6 +212,15 @@ export class Notifications implements StreamingClientExtension {
   }
 
   makeBulkSubscribeRequest (topics: string[], options): Promise<AxiosResponse<ChannelTopicsEntityListing>> {
+    // Cancel any in-flight retry from a previous bulk subscribe. If the topic list has changed
+    // (subscribe/unsubscribe called between retries), the stale request would send an outdated
+    // topic list. Since bulk subscribes with replace=true use PUT (full replacement), only the
+    // most recent request matters.
+    if (this.pendingBulkSubscribeRetry && !this.pendingBulkSubscribeRetry.hasCompleted()) {
+      this.client.logger.info('Cancelling previous bulk subscribe retry — new request supersedes it');
+      this.pendingBulkSubscribeRetry.cancel(new Error('Superseded by newer bulk subscribe request'));
+    }
+
     const requestOptions: RequestApiOptions = {
       method: options.replace ? 'put' : 'post',
       host: this.client.config.apiHost,
@@ -225,7 +236,10 @@ export class Notifications implements StreamingClientExtension {
       path += '?ignoreErrors=true';
     }
 
-    return this.client.http.requestApiWithRetry(path, requestOptions, 2000).promise;
+    const retry = this.client.http.requestApiWithRetry(path, requestOptions, 2000);
+    this.pendingBulkSubscribeRetry = retry;
+
+    return retry.promise;
   }
 
   createSubscription (topic: string, handler: (obj?: any) => void): void {
@@ -432,7 +446,24 @@ export class Notifications implements StreamingClientExtension {
       this.subscriptions = {};
     }
 
-    const response = await this.makeBulkSubscribeRequest(toSubscribe, options);
+    let response: AxiosResponse<ChannelTopicsEntityListing> | undefined;
+    try {
+      response = await this.makeBulkSubscribeRequest(toSubscribe, options);
+    } catch (err: any) {
+      // If this request was cancelled because a newer bulk subscribe superseded it,
+      // return an 'Unknown' state for all topics. The superseding request will carry
+      // the current desired topic list and handle the actual subscription.
+      if (err?.message?.includes('Superseded by newer bulk subscribe request')) {
+        this.client.logger.debug('Bulk subscribe was superseded, deferring to newer request');
+        const result: BulkSubscribeResult = {};
+        for (const topic of toSubscribe) {
+          result[topic] = { topic, state: 'Unknown' };
+        }
+        return result;
+      }
+      throw err;
+    }
+
     let topicResponseEntities: ChannelTopicResponseEntity[] = [];
     if (response && response.data && 'entities' in response.data && Array.isArray(response.data.entities)) {
       topicResponseEntities = response.data.entities;

--- a/test/unit/notifications.test.ts
+++ b/test/unit/notifications.test.ts
@@ -1216,5 +1216,22 @@ describe('Notifications', () => {
       await expect(notification.bulkSubscribe(['topicA'], { replace: true }))
         .rejects.toThrow('Network failure');
     });
+
+    it('should rethrow when error has no message property', async () => {
+      const errorWithoutMessage = { code: 'ECONNRESET' };
+      jest.spyOn(notification, 'makeBulkSubscribeRequest')
+        .mockRejectedValueOnce(errorWithoutMessage);
+
+      await expect(notification.bulkSubscribe(['topicA'], { replace: true }))
+        .rejects.toEqual(errorWithoutMessage);
+    });
+
+    it('should rethrow when error is null', async () => {
+      jest.spyOn(notification, 'makeBulkSubscribeRequest')
+        .mockRejectedValueOnce(null);
+
+      await expect(notification.bulkSubscribe(['topicA'], { replace: true }))
+        .rejects.toBeNull();
+    });
   });
 });

--- a/test/unit/notifications.test.ts
+++ b/test/unit/notifications.test.ts
@@ -140,6 +140,7 @@ describe('Notifications', () => {
         channelId,
         apiHost: 'example.com',
       });
+      client.connected = true;
       bulkSubscribeUrl = `https://api.example.com/api/v2/notifications/channels/${channelId}/subscriptions`;
       axiosMock.onPut(bulkSubscribeUrl).reply((config) => {
         const topics = JSON.parse(config.data).map((topic) => topic.id);
@@ -738,6 +739,7 @@ describe('Notifications', () => {
         apiHost: 'example.com',
         channelId: 'notification-test-channel'
       });
+      client.connected = true;
       const notification = new Notifications(client);
       notification.stanzaInstance = fakeStanza;
       const xmppSubscribeSpy = jest.fn().mockResolvedValue({});
@@ -1135,6 +1137,7 @@ describe('Notifications', () => {
         apiHost: 'example.com',
         channelId: 'notification-test-channel'
       });
+      client.connected = true;
       notification = new Notifications(client);
       notification.stanzaInstance = getFakeStanzaClient();
     });
@@ -1232,6 +1235,93 @@ describe('Notifications', () => {
 
       await expect(notification.bulkSubscribe(['topicA'], { replace: true }))
         .rejects.toBeNull();
+    });
+
+    it('should wait for connected event before making bulk subscribe request when disconnected', async () => {
+      client.connected = false;
+      const requestSpy = jest.spyOn(client.http, 'requestApiWithRetry').mockReturnValue({
+        promise: Promise.resolve({ data: { entities: [] } }),
+        cancel: jest.fn(),
+        complete: jest.fn(),
+        hasCompleted: () => false,
+        _id: 'test-id'
+      } as any);
+
+      // Start the request — it should not fire immediately
+      const promise = notification.makeBulkSubscribeRequest(['topicA'], { replace: true });
+      expect(requestSpy).not.toHaveBeenCalled();
+
+      // Simulate reconnection
+      client.connected = true;
+      (client as any).emit('connected');
+
+      await promise;
+      expect(requestSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should use the fresh channel ID after waiting for reconnection', async () => {
+      client.connected = false;
+      const oldChannelId = notification.stanzaInstance!.channelId;
+
+      const requestSpy = jest.spyOn(client.http, 'requestApiWithRetry').mockReturnValue({
+        promise: Promise.resolve({ data: { entities: [] } }),
+        cancel: jest.fn(),
+        complete: jest.fn(),
+        hasCompleted: () => false,
+        _id: 'test-id'
+      } as any);
+
+      const promise = notification.makeBulkSubscribeRequest(['topicA'], { replace: true });
+
+      // Simulate reconnection with a new stanza instance (new channel)
+      const newStanza = getFakeStanzaClient();
+      newStanza.channelId = 'brand-new-channel';
+      notification.stanzaInstance = newStanza;
+      client.connected = true;
+      (client as any).emit('connected');
+
+      await promise;
+
+      // Verify the request used the NEW channel ID, not the old one
+      const calledPath = requestSpy.mock.calls[0][0];
+      expect(calledPath).toContain('brand-new-channel');
+      expect(calledPath).not.toContain(oldChannelId);
+    });
+
+    it('should cancel pending connected-wait when a new bulk subscribe supersedes it', async () => {
+      client.connected = false;
+
+      // Start first request — will wait for connected
+      const firstPromise = notification.makeBulkSubscribeRequest(['topicA'], { replace: true });
+
+      // Second request while first is waiting — should cancel the first
+      client.connected = true;
+      const requestSpy = jest.spyOn(client.http, 'requestApiWithRetry').mockReturnValue({
+        promise: Promise.resolve({ data: { entities: [] } }),
+        cancel: jest.fn(),
+        complete: jest.fn(),
+        hasCompleted: () => false,
+        _id: 'test-id'
+      } as any);
+
+      await notification.makeBulkSubscribeRequest(['topicA', 'topicB'], { replace: true });
+
+      // The first promise should reject with supersession error
+      await expect(firstPromise).rejects.toThrow('Superseded by newer bulk subscribe request');
+    });
+
+    it('should proceed immediately when client is already connected', async () => {
+      client.connected = true;
+      const requestSpy = jest.spyOn(client.http, 'requestApiWithRetry').mockReturnValue({
+        promise: Promise.resolve({ data: { entities: [] } }),
+        cancel: jest.fn(),
+        complete: jest.fn(),
+        hasCompleted: () => false,
+        _id: 'test-id'
+      } as any);
+
+      await notification.makeBulkSubscribeRequest(['topicA'], { replace: true });
+      expect(requestSpy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/test/unit/notifications.test.ts
+++ b/test/unit/notifications.test.ts
@@ -1125,4 +1125,96 @@ describe('Notifications', () => {
     expect(spy).toHaveBeenCalledWith('notify', { topic: 'duplicate_id', data: payload });
     expect(spy).toHaveBeenCalledWith('notify:duplicate_id', payload);
   });
+
+  describe('bulk subscribe retry supersession', () => {
+    let client: Client;
+    let notification: Notifications;
+
+    beforeEach(() => {
+      client = new Client({
+        apiHost: 'example.com',
+        channelId: 'notification-test-channel'
+      });
+      notification = new Notifications(client);
+      notification.stanzaInstance = getFakeStanzaClient();
+    });
+
+    it('should cancel a pending retry when a new bulk subscribe request is made', async () => {
+      // First request: simulate a pending retry that hasn't completed
+      const cancelFn = jest.fn();
+      const firstRetry = {
+        promise: new Promise(() => {}), // never resolves (simulates in-flight retry)
+        cancel: cancelFn,
+        complete: jest.fn(),
+        hasCompleted: () => false,
+        _id: 'test-id'
+      };
+      jest.spyOn(client.http, 'requestApiWithRetry').mockReturnValueOnce(firstRetry as any);
+
+      // Start first request (don't await — it will never resolve)
+      const firstPromise = notification.makeBulkSubscribeRequest(['topicA'], { replace: true });
+
+      // Second request: should cancel the first
+      const secondRetry = {
+        promise: Promise.resolve({ data: { entities: [] } }),
+        cancel: jest.fn(),
+        complete: jest.fn(),
+        hasCompleted: () => false,
+        _id: 'test-id-2'
+      };
+      jest.spyOn(client.http, 'requestApiWithRetry').mockReturnValueOnce(secondRetry as any);
+
+      await notification.makeBulkSubscribeRequest(['topicA', 'topicB'], { replace: true });
+
+      expect(cancelFn).toHaveBeenCalledWith(expect.objectContaining({
+        message: expect.stringContaining('Superseded by newer bulk subscribe request')
+      }));
+    });
+
+    it('should not cancel a retry that has already completed', async () => {
+      const cancelFn = jest.fn();
+      const completedRetry = {
+        promise: Promise.resolve({ data: { entities: [] } }),
+        cancel: cancelFn,
+        complete: jest.fn(),
+        hasCompleted: () => true,
+        _id: 'test-id'
+      };
+      jest.spyOn(client.http, 'requestApiWithRetry').mockReturnValueOnce(completedRetry as any);
+
+      await notification.makeBulkSubscribeRequest(['topicA'], { replace: true });
+
+      // Second request
+      const secondRetry = {
+        promise: Promise.resolve({ data: { entities: [] } }),
+        cancel: jest.fn(),
+        complete: jest.fn(),
+        hasCompleted: () => false,
+        _id: 'test-id-2'
+      };
+      jest.spyOn(client.http, 'requestApiWithRetry').mockReturnValueOnce(secondRetry as any);
+
+      await notification.makeBulkSubscribeRequest(['topicA', 'topicB'], { replace: true });
+
+      expect(cancelFn).not.toHaveBeenCalled();
+    });
+
+    it('should return Unknown state for all topics when bulk subscribe is superseded', async () => {
+      jest.spyOn(notification, 'makeBulkSubscribeRequest')
+        .mockRejectedValueOnce(new Error('Superseded by newer bulk subscribe request'));
+
+      const result = await notification.bulkSubscribe(['topicA', 'topicB'], { replace: true });
+
+      expect(result['topicA']).toEqual({ topic: 'topicA', state: 'Unknown' });
+      expect(result['topicB']).toEqual({ topic: 'topicB', state: 'Unknown' });
+    });
+
+    it('should still throw non-supersession errors from bulk subscribe', async () => {
+      jest.spyOn(notification, 'makeBulkSubscribeRequest')
+        .mockRejectedValueOnce(new Error('Network failure'));
+
+      await expect(notification.bulkSubscribe(['topicA'], { replace: true }))
+        .rejects.toThrow('Network failure');
+    });
+  });
 });


### PR DESCRIPTION
Retry on `ECONNRESET`: Switched from requestApi to requestApiWithRetry with maxAttempts: 3 and a 2-second retry interval.

Track topic list change: Track the pending retry via pendingBulkSubscribeRetry. When a new makeBulkSubscribeRequest is issued (because the debounce fired again with an updated topic list), the old retry is cancelled. The cancelled bulkSubscribe returns 'Unknown' state for its topics rather than throwing, since the superseding request will carry the correct desired state. 

This prevents:
A stale PUT from overwriting the server with an outdated topic list
Unnecessary duplicate requests when the topic list has already changed
Missed subscriptions that were added between retry attempts