### PR TITLE
[STREAM-2176] Allow userId to be passed as client option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 * [STREAM-1784](https://inindca.atlassian.net/browse/STREAM-1784) - Properly handle session not found for terminate stanza
 * [STREAM-2184](https://inindca.atlassian.net/browse/STREAM-2184) - Update stanza to v12.22.1
+* [STREAM-2176](https://inindca.atlassian.net/browse/STREAM-2176) - Allow userId to be passed in as a client option so it doesn't need to be fetched again
 
 # [v20.0.1](https://github.com/purecloudlabs/genesys-cloud-streaming-client/compare/v20.0.0...v20.0.1)
 ### Changed

--- a/src/client.ts
+++ b/src/client.ts
@@ -92,6 +92,7 @@ export class Client extends EventEmitter {
       jwt: options.jwt,
       jid: options.jid,
       jidResource: options.jidResource,
+      userId: options.userId,
       channelId: null as any, // created on connect
       appName: options.appName,
       appVersion: options.appVersion,

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -9,6 +9,7 @@ export interface IClientOptions {
   authToken?: string;
   jwt?: string;
   jid?: string;
+  userId?: string;
   jidResource?: string;
   reconnectOnNoLongerSubscribed?: boolean;
   optOutOfWebrtcStatsTelemetry?: boolean;

--- a/test/unit/client.test.ts
+++ b/test/unit/client.test.ts
@@ -1281,7 +1281,7 @@ describe('prepareForConnect', () => {
     httpSpy = client.http.requestApi = jest.fn().mockImplementation((path) => {
       const promise = new Promise((resolve, reject) => {
         if (path === 'users/me') {
-          return resolve({ data: { chat: { jabberId: 'myRequestedJid' } } });
+          return resolve({ data: { id: 'abc123', chat: { jabberId: 'myRequestedJid' } } });
         } else if (path.startsWith('notifications/channels')) {
           return resolve({ data: { id: 'myNotiChannel' } });
         }
@@ -1310,7 +1310,9 @@ describe('prepareForConnect', () => {
     expect(httpSpy).not.toHaveBeenCalled();
   });
 
-  it('should fetch jid if it doesnt have one', async () => {
+  it('should fetch jid if not present in config', async () => {
+    client.config.userId = 'abc123';
+
     await client['prepareForConnect']();
     expect(httpSpy).toHaveBeenCalledTimes(2);
     expect(client.config).toEqual(expect.objectContaining({
@@ -1322,7 +1324,7 @@ describe('prepareForConnect', () => {
     expect(setConfigSpy).toHaveBeenCalled();
   });
 
-  it('should not fetch jid if it already had one', async () => {
+  it('should not fetch jid if already present in config', async () => {
     client.config.userId = 'abc123';
     client.config.jid = 'myJid';
 
@@ -1331,6 +1333,33 @@ describe('prepareForConnect', () => {
     expect(client.config).toEqual(expect.objectContaining({
       jid: 'myJid',
       channelId: 'myNotiChannel'
+    }));
+
+    expect(client.hardReconnectRequired).toBeFalsy();
+    expect(setConfigSpy).toHaveBeenCalled();
+  });
+
+  it('should fetch userId if not present in config', async () => {
+    client.config.jid = 'myJid';
+
+    await client['prepareForConnect']();
+    expect(httpSpy).toHaveBeenCalledTimes(2);
+    expect(client.config).toEqual(expect.objectContaining({
+      userId: 'abc123'
+    }));
+
+    expect(client.hardReconnectRequired).toBeFalsy();
+    expect(setConfigSpy).toHaveBeenCalled();
+  });
+
+  it('should not fetch userId if already present in config', async () => {
+    client.config.userId = 'abc123';
+    client.config.jid = 'myJid';
+
+    await client['prepareForConnect']();
+    expect(httpSpy).toHaveBeenCalledTimes(1);
+    expect(client.config).toEqual(expect.objectContaining({
+      userId: 'abc123'
     }));
 
     expect(client.hardReconnectRequired).toBeFalsy();


### PR DESCRIPTION
This has been requested so it doesn't need to be fetched again (we do the same for the `jid`).