### PR TITLE
[STREAM-2207] Debounce `claimAlertingLeader` to prevent hammering the endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [STREAM-1784](https://inindca.atlassian.net/browse/STREAM-1784) - Properly handle session not found for terminate stanza
 * [STREAM-2184](https://inindca.atlassian.net/browse/STREAM-2184) - Update stanza to v12.22.1
 * [STREAM-2176](https://inindca.atlassian.net/browse/STREAM-2176) - Allow userId to be passed in as a client option so it doesn't need to be fetched again
+* [STREAM-2207](https://inindca.atlassian.net/browse/STREAM-2207) - Debounce `claimAlertingLeader` to prevent hammering the endpoint
 
 # [v20.0.1](https://github.com/purecloudlabs/genesys-cloud-streaming-client/compare/v20.0.0...v20.0.1)
 ### Changed

--- a/src/alerting-leader.ts
+++ b/src/alerting-leader.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import debounce from 'debounce-promise';
 import { AlertableInteractionTypes, IAlertingStatus, IClientOptions, ILeaderStatus, RequestApiOptions, StreamingClientExtension, StreamingClientErrorTypes } from './types/interfaces';
 import { Client } from './client';
 import { EventEmitter } from 'events';
@@ -10,11 +11,13 @@ export class AlertingLeaderExtension extends EventEmitter implements StreamingCl
   private alertableInteractionTypes: AlertableInteractionTypes[];
   private getLeaderAbortController?: AbortController;
   private leaderStatus: ILeaderStatus = {};
+  private debouncedClaimAlertingLeader: () => Promise<void>;
 
   constructor (private client: Client, options: IClientOptions) {
     super();
 
     this.alertableInteractionTypes = options.alertableInteractionTypes ?? [];
+    this.debouncedClaimAlertingLeader = debounce(this.claimAlertingLeader.bind(this), 300);
   }
 
   handleStanzaInstanceChange (stanzaInstance: NamedAgent) {
@@ -169,7 +172,7 @@ export class AlertingLeaderExtension extends EventEmitter implements StreamingCl
     return {
       on: this.on.bind(this),
       off: this.off.bind(this),
-      claimAlertingLeader: this.claimAlertingLeader.bind(this),
+      claimAlertingLeader: this.debouncedClaimAlertingLeader,
       getLeaderStatus: () => { return this.leaderStatus; },
       leaderStatus: this.leaderStatus
     };

--- a/test/unit/alerting-leader.test.ts
+++ b/test/unit/alerting-leader.test.ts
@@ -512,7 +512,24 @@ describe('AlertingLeader', () => {
   });
 
   describe('claimAlertingLeader', () => {
-    it('should claim alerting leader', () => {
+    it('should claim alerting leader', async () => {
+      const connectionId = 'connection123';
+      const alertingLeaderPath = 'users/alertingleader';
+      const httpSpy = jest.fn().mockResolvedValue({});
+      const fakeClient = new FakeClient({}) as unknown as Client;
+      fakeClient.http.requestApi = httpSpy;
+      const clientOptions = { alertableInteractionTypes: [ AlertableInteractionTypes.voice ] };
+      const alertingLeader = new AlertingLeaderExtension(fakeClient, clientOptions as IClientOptions);
+      alertingLeader['connectionId'] = connectionId;
+      const alertingLeaderExposedApi = alertingLeader.expose;
+
+      await alertingLeaderExposedApi.claimAlertingLeader();
+
+      expect(httpSpy.mock.calls[0][0]).toBe(alertingLeaderPath);
+      expect(httpSpy.mock.calls[0][1]).toMatchObject({ data: { connectionId: connectionId } });
+    });
+
+    it('should debounce multiple claim requests', async () => {
       const connectionId = 'connection123';
       const alertingLeaderPath = 'users/alertingleader';
       const httpSpy = jest.fn().mockResolvedValue({});
@@ -524,9 +541,10 @@ describe('AlertingLeader', () => {
       const alertingLeaderExposedApi = alertingLeader.expose;
 
       alertingLeaderExposedApi.claimAlertingLeader();
+      alertingLeaderExposedApi.claimAlertingLeader();
+      await alertingLeaderExposedApi.claimAlertingLeader();
 
-      expect(httpSpy.mock.calls[0][0]).toBe(alertingLeaderPath);
-      expect(httpSpy.mock.calls[0][1]).toMatchObject({ data: { connectionId: connectionId } });
+      expect(httpSpy.mock.calls).toHaveLength(1);
     });
 
     it('should throw generic StreamingClientError if client is not configured for any alertable interactions', async () => {


### PR DESCRIPTION
The original report of this was due to an auth flow issue, but Zach and I were talking and decided that it'd be good to mitigate the loop that was created (see ticket for more info).

I tested and this was enough to break the loop; a few requests still happen, but **far** fewer and with lower frequency. In a test I did, about 100 requests were made in the span of 13s before this change. After this change, 2 requests were made in 3s.